### PR TITLE
feat: add trade-partners CLI command for owner matchmaking

### DIFF
--- a/.claude/commands/trade-partners.md
+++ b/.claude/commands/trade-partners.md
@@ -1,0 +1,72 @@
+# trade-partners
+
+Ranks every other owner in a league by **trade-partner compatibility**
+with you. Combines three signals into a single engagement score:
+
+1. **Archetype synergy** — rebuilders pair with contenders, contenders
+   avoid each other, etc.
+2. **Positional fit** — your surplus position vs their need, and vice versa
+3. **History** — past completed trades between you, weighted by activity
+   and net KTC swing
+
+## When to use this skill
+
+- "Who should I trade with?"
+- "Who's the best partner for me right now?"
+- "Which owners are worth engaging?"
+- "Rank my league by trade compatibility"
+- "Who exploits me — who do I exploit?"
+
+## How to run
+
+### Default — top 12 partners
+```bash
+python3 -m sleeper.cli trade-partners camfleety --league "Meat Market"
+```
+
+### Top 5 only
+```bash
+python3 -m sleeper.cli trade-partners camfleety --league "OGs" --top 5
+```
+
+### 1QB league
+```bash
+python3 -m sleeper.cli trade-partners camfleety --league "Slime Season" --format 1qb
+```
+
+## Reading the output
+
+```
+#  Owner       Score  Arch         Syn  Pos  Hist  Rationale
+1  romanempire   +12  REBUILDING   +5   +4   +3    REBUILDING · wants your QB · 4 prior trades (+13,200 net)
+2  zaybanga      +9   CONTENDER    +5   +2   +2    CONTENDER · has WR you need · 3 prior trades (+8,400 net)
+```
+
+- **Score** — final engagement priority (typical range −5 to +15)
+- **Syn** — archetype synergy points (−3 to +5)
+- **Pos** — positional fit (2 pts per surplus↔need overlap)
+- **Hist** — historical trade record points (activity + net KTC ÷ 5K)
+- **Rationale** — one-line summary you can paste into a DM
+
+## Useful follow-ups
+
+| Goal | Chain to |
+|---|---|
+| Build a trade for the top partner | `find-trades --include <their player>` |
+| Verify a specific offer | `trade-check --give ... --get ...` |
+| See historical trades with that owner | `proposed-trades --user <name>` |
+| Fire the trade | `send-trade --to-roster <id> --send ... --get ...` |
+
+## Key context
+
+- **Archetype source**: lazy-loads `analytics/gm_mode.py` with the same
+  classification logic as the `gm-mode` command. Owners whose roster
+  can't be classified (early season, no production data) get archetype
+  `UNKNOWN` and a 0 synergy score.
+- **History is optional**: with `SLEEPER_TOKEN` set, the command pulls
+  completed league trades and computes the user-net-KTC per partner.
+  Without auth, every partner gets the small "untapped" history bonus.
+- **3-way trades are skipped** in history scoring — they distort the
+  pairwise net.
+- **Top score caps**: `Hist` is capped at ±8 so a single huge historical
+  win doesn't dominate; macro fit matters more than past results.

--- a/python/src/sleeper/analytics/partner_match.py
+++ b/python/src/sleeper/analytics/partner_match.py
@@ -1,0 +1,215 @@
+"""Trade-partner matchmaking — score how attractive each other owner in a
+league is as a trade partner for the user.
+
+Three signals combine into a single compatibility score:
+
+1. **Archetype synergy** — a rebuilder wants contenders to buy their vets
+   for picks; a contender wants rebuilders/pretenders to sell their stars.
+   Two CONTENDERs fighting over the same assets is a bad match. The
+   `_SYNERGY` table encodes this explicitly.
+
+2. **Positional fit** — the user's surplus position is the partner's need,
+   and vice versa. Each overlap = +2 to the score.
+
+3. **History** — past completed trades between the two rosters.
+   - More history = more engaged partner (capped, so a single grumpy
+     veteran trade-partner doesn't dominate)
+   - User's net KTC win/loss with that partner = trust signal
+
+The output is a ranked list with a human-readable rationale per partner,
+so the CLI can show "engage romanempire (rebuilder) — your QB surplus
+fits his QB need, +13K KTC history" instead of just a number.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+
+Archetype = Literal[
+    "CONTENDER", "RELOADING", "REBUILDING", "PRETENDER", "UNKNOWN"
+]
+
+
+# Archetype synergy matrix: (user_archetype, partner_archetype) -> score.
+# Range: -3 to +5. Captures "who wants to trade what" at the macro level.
+_SYNERGY: dict[tuple[str, str], int] = {
+    # User REBUILDING wants contenders who'll buy vets for picks
+    ("REBUILDING", "CONTENDER"):  5,
+    ("REBUILDING", "RELOADING"):  3,
+    ("REBUILDING", "PRETENDER"):  4,   # they SHOULD be selling vets to you
+    ("REBUILDING", "REBUILDING"): 1,
+    # User CONTENDER wants rebuilders/pretenders to sell stars
+    ("CONTENDER", "REBUILDING"):  5,
+    ("CONTENDER", "PRETENDER"):   4,
+    ("CONTENDER", "RELOADING"):   2,
+    ("CONTENDER", "CONTENDER"):  -2,   # competing for same assets
+    # User RELOADING is flexible, fits most
+    ("RELOADING", "CONTENDER"):   3,
+    ("RELOADING", "REBUILDING"):  3,
+    ("RELOADING", "PRETENDER"):   2,
+    ("RELOADING", "RELOADING"):   0,
+    # User PRETENDER's best move is selling vets while they hold value
+    ("PRETENDER", "CONTENDER"):   5,
+    ("PRETENDER", "REBUILDING"):  3,
+    ("PRETENDER", "RELOADING"):   2,
+    ("PRETENDER", "PRETENDER"):  -1,
+}
+
+
+def archetype_synergy(user_archetype: str, partner_archetype: str) -> int:
+    """Return the synergy score for a (user, partner) archetype pair.
+
+    Unknown archetypes return 0 (neutral). This keeps the algorithm safe
+    when gm_mode can't classify a roster (e.g., season hasn't started and
+    production rank is unreliable).
+    """
+    return _SYNERGY.get((user_archetype, partner_archetype), 0)
+
+
+@dataclass
+class PositionalFit:
+    """Overlap between user surplus and partner need (and vice versa)."""
+
+    user_offers: list[str] = field(default_factory=list)
+    """Positions where the user is STRONG and the partner is WEAK —
+    things the user can ship for upgrades elsewhere."""
+
+    partner_offers: list[str] = field(default_factory=list)
+    """Positions where the partner is STRONG and the user is WEAK —
+    things the user wants to acquire."""
+
+    score: int = 0
+
+
+def positional_fit(
+    user_strong: set[str],
+    user_weak: set[str],
+    partner_strong: set[str],
+    partner_weak: set[str],
+) -> PositionalFit:
+    """Compute mutual positional fit between user and partner.
+
+    Each overlap (user surplus ↔ partner need OR partner surplus ↔ user
+    need) is worth 2 points. The bi-directional flow is what makes a
+    trade actually transactable; one-sided fits often stall.
+    """
+    user_offers = sorted(user_strong & partner_weak)
+    partner_offers = sorted(partner_strong & user_weak)
+    score = len(user_offers) * 2 + len(partner_offers) * 2
+    return PositionalFit(
+        user_offers=user_offers,
+        partner_offers=partner_offers,
+        score=score,
+    )
+
+
+@dataclass
+class TradeHistory:
+    """Compressed completed-trade record between two rosters."""
+
+    total: int = 0
+    """Total completed trades between user and this partner."""
+
+    user_wins: int = 0
+    user_losses: int = 0
+    fair: int = 0
+    user_net_ktc: int = 0
+    """Sum of adjusted_overpay across all scored trades (positive = user
+    won more value than they gave). Unscored trades contribute 0."""
+
+
+def history_score(history: TradeHistory) -> int:
+    """Score a partner based on past completed trades with the user.
+
+    Logic:
+    - 0 trades  → +1 (small upside for an untapped channel — every league
+      member is worth a first conversation)
+    - 1-2 trades → activity counts, KTC swing dominates
+    - 3+ trades → high engagement bonus, KTC swing capped at ±3
+
+    KTC swing is scaled at 5K = 1 point. A +15K net partner is a clear
+    "they overpay you" channel (+3). A −15K partner exploits you (−3).
+    """
+    if history.total == 0:
+        return 1   # fresh — small "worth trying" upside
+    activity = min(history.total, 5)
+    ktc_factor = history.user_net_ktc // 5000
+    return activity + max(-3, min(3, ktc_factor))
+
+
+@dataclass
+class PartnerScore:
+    """Final compatibility breakdown for one potential partner."""
+
+    owner: str
+    roster_id: int
+    archetype: str
+    synergy: int
+    positional: PositionalFit
+    history: TradeHistory
+    history_pts: int
+    total: int
+    rationale: str
+
+
+def score_partner(
+    *,
+    owner: str,
+    roster_id: int,
+    user_archetype: str,
+    partner_archetype: str,
+    user_strong: set[str],
+    user_weak: set[str],
+    partner_strong: set[str],
+    partner_weak: set[str],
+    history: TradeHistory,
+) -> PartnerScore:
+    """Combine the three signals into one PartnerScore.
+
+    Final score = synergy + positional.score + history_pts.
+    Typical range: -5 (avoid) to +15 (engage immediately).
+    """
+    syn = archetype_synergy(user_archetype, partner_archetype)
+    fit = positional_fit(user_strong, user_weak, partner_strong, partner_weak)
+    hist_pts = history_score(history)
+    total = syn + fit.score + hist_pts
+
+    bits: list[str] = []
+    bits.append(f"{partner_archetype}")
+    if fit.user_offers:
+        bits.append(f"wants your {'+'.join(fit.user_offers)}")
+    if fit.partner_offers:
+        bits.append(f"has {'+'.join(fit.partner_offers)} you need")
+    if history.total > 0:
+        sign = "+" if history.user_net_ktc >= 0 else ""
+        bits.append(
+            f"{history.total} prior trades ({sign}{history.user_net_ktc:,} net)"
+        )
+    else:
+        bits.append("no prior history")
+    rationale = " · ".join(bits)
+
+    return PartnerScore(
+        owner=owner,
+        roster_id=roster_id,
+        archetype=partner_archetype,
+        synergy=syn,
+        positional=fit,
+        history=history,
+        history_pts=hist_pts,
+        total=total,
+        rationale=rationale,
+    )
+
+
+def rank_partners(scores: list[PartnerScore]) -> list[PartnerScore]:
+    """Sort partners by total score, descending (best engage targets first).
+
+    Stable sort: ties broken by synergy, then history_pts, then owner name
+    so the output is deterministic across runs.
+    """
+    return sorted(
+        scores,
+        key=lambda s: (-s.total, -s.synergy, -s.history_pts, s.owner.lower()),
+    )

--- a/python/src/sleeper/cli/_main.py
+++ b/python/src/sleeper/cli/_main.py
@@ -19,6 +19,7 @@ from sleeper.cli.analysis import (
     cmd_gm_mode,
     cmd_picks,
     cmd_proposed_trades,
+    cmd_trade_partners,
 )
 from sleeper.cli.send_trade import cmd_send_trade
 from sleeper.cli.trades import (
@@ -158,6 +159,16 @@ def main() -> None:
     gm.add_argument("--owner", help="Analyze another owner in the same league (by display name)")
     gm.add_argument("--format", choices=["sf", "1qb"], default="sf", help="Format (default: sf)")
 
+    # trade-partners
+    tp_ = subparsers.add_parser("trade-partners",
+                                help="Rank league owners by trade-partner compatibility "
+                                     "(archetype synergy + positional fit + history)")
+    tp_.add_argument("username", help="Sleeper username")
+    tp_.add_argument("--league", help="League name filter")
+    tp_.add_argument("--format", choices=["sf", "1qb"], default="sf", help="Format (default: sf)")
+    tp_.add_argument("--top", type=int, default=12,
+                     help="Max partners to display (default: 12)")
+
     # proposed-trades
     pt = subparsers.add_parser("proposed-trades",
                                help="List every trade in the league (any status) with KTC valuation")
@@ -256,6 +267,8 @@ def main() -> None:
         cmd_send_trade(args)
     elif args.command == "gm-mode":
         cmd_gm_mode(args)
+    elif args.command == "trade-partners":
+        cmd_trade_partners(args)
     elif args.command in agent_handlers:
         agent_handlers[args.command](args)
     else:

--- a/python/src/sleeper/cli/analysis.py
+++ b/python/src/sleeper/cli/analysis.py
@@ -302,6 +302,204 @@ def cmd_gm_mode(args) -> None:
     print("=" * 78)
 
 
+def cmd_trade_partners(args) -> None:
+    """Rank other league owners by trade-partner compatibility.
+
+    For each rival roster, classify their archetype with gm_mode, derive
+    their positional strengths/weaknesses, optionally fold in past
+    completed-trade history with the user, and produce a single
+    "engagement priority" score. Output is a ranked table with rationale.
+
+    Auth: optional. With SLEEPER_TOKEN, the history factor uses real
+    league-wide completed trades. Without, history defaults to zero.
+    """
+    import asyncio
+    from sleeper.client import SleeperClient
+    from sleeper.enrichment.ktc import fetch_ktc_players
+    from sleeper.analytics.partner_match import (
+        PartnerScore,
+        TradeHistory,
+        rank_partners,
+        score_partner,
+    )
+    from sleeper.analytics.find_trades_engine import package_overpay
+
+    user, league = _resolve_league(args.username, args.league)
+    print(f"League: {league.name}")
+    rosters, sleeper_players = _fetch_roster_and_players(league.league_id)
+
+    async def _get_users():
+        async with SleeperClient() as client:
+            return await client.leagues.get_users(league.league_id)
+    league_users = asyncio.run(_get_users())
+    user_display: dict[str, str] = {}
+    for u in (league_users or []):
+        uid = str(u.user_id) if hasattr(u, "user_id") else ""
+        disp = u.display_name if hasattr(u, "display_name") else ""
+        if uid and disp:
+            user_display[uid] = disp
+
+    my_roster = next((r for r in rosters if r.owner_id == user.user_id), None)
+    if my_roster is None:
+        print(f"No roster found for '{args.username}' in {league.name}.")
+        sys.exit(1)
+
+    print("Fetching KTC values...")
+    ktc_players = fetch_ktc_players()
+    sleeper_to_ktc = _build_sleeper_to_ktc(ktc_players, sleeper_players)
+
+    # Lazy-load gm_mode via path (analytics/__init__.py has a stale import
+    # that can fail in some installs — same pattern cmd_gm_mode uses).
+    import importlib.util as _iu, sys as _sys
+    _pkg_root = os.path.dirname(os.path.dirname(__file__))
+    _gm_path = os.path.join(_pkg_root, "analytics", "gm_mode.py")
+    _spec = _iu.spec_from_file_location("_sleeper_gm_mode_partners", _gm_path)
+    _gm = _iu.module_from_spec(_spec)
+    _sys.modules["_sleeper_gm_mode_partners"] = _gm
+    _spec.loader.exec_module(_gm)
+
+    def _classify(roster):
+        """Run gm_mode on a roster and return (archetype, strong_set, weak_set)."""
+        try:
+            report = _gm.generate_gm_report(
+                my_roster=roster,
+                all_rosters=rosters,
+                sleeper_players=sleeper_players,
+                sleeper_to_ktc=sleeper_to_ktc,
+                user_display=user_display,
+                fmt=args.format,
+            )
+            arch = report.archetype.archetype if report.archetype else "UNKNOWN"
+            strong = {p.position for p in report.positions if p.strength_score >= 0.4}
+            weak = {p.position for p in report.positions if p.strength_score <= -0.4}
+            return arch, strong, weak
+        except Exception:
+            return "UNKNOWN", set(), set()
+
+    print(f"Classifying {len(rosters)} rosters...")
+    user_arch, user_strong, user_weak = _classify(my_roster)
+
+    # Optional: pull league-wide trade history
+    histories: dict[int, TradeHistory] = {}
+    try:
+        from sleeper.auth import SleeperAuthClient
+        with SleeperAuthClient() as auth:
+            trades = auth.get_trades(
+                league.league_id,
+                statuses=["complete"],
+                roster_ids=[r.roster_id for r in rosters],
+                limit=500,
+            )
+        seen: set[str] = set()
+        my_rid = my_roster.roster_id
+        for t in trades:
+            tid = t.get("transaction_id")
+            if not tid or tid in seen:
+                continue
+            seen.add(tid)
+            rids = t.get("roster_ids") or []
+            if my_rid not in rids:
+                continue
+            # Build per-side KTC totals from `adds`
+            adds = t.get("adds") or {}
+            per_side: dict[int, list[int]] = {int(r): [] for r in rids}
+            for pid, rid in adds.items():
+                try:
+                    rid_i = int(rid)
+                except (TypeError, ValueError):
+                    continue
+                ktc_p = sleeper_to_ktc.get(pid)
+                val = (ktc_p.superflex.value if ktc_p and ktc_p.superflex else 0) or 0
+                per_side.setdefault(rid_i, []).append(val)
+            # Pair vs other rosters (skip 3-way trades from scoring)
+            others = [r for r in rids if r != my_rid]
+            if len(others) != 1:
+                continue
+            other = int(others[0])
+            send_vals = [v for v in per_side.get(other, []) if v > 0]
+            recv_vals = [v for v in per_side.get(my_rid, []) if v > 0]
+            if not send_vals and not recv_vals:
+                continue
+            h = histories.setdefault(other, TradeHistory())
+            h.total += 1
+            # Score from user's perspective: user sends recv_vals... wait,
+            # `adds` shows who RECEIVED each player. So per_side[my_rid] is
+            # what user RECEIVED. The OTHER's per_side is what user GAVE.
+            send_for_score = recv_vals or [0]   # what user "spent" to receive
+            target_total = sum(per_side.get(other, []))
+            if recv_vals and per_side.get(other):
+                # User sent per_side[other] (what other received), received per_side[my_rid]
+                # Use package_overpay from user's perspective: user sent A, got B target
+                sent = per_side.get(other, [])
+                got = sum(per_side.get(my_rid, []))
+                if got > 0 and sent:
+                    score = package_overpay(send_values=sent, target_ktc=got)
+                    # adjusted_overpay POSITIVE = user overpaid (gave more value)
+                    # Flip for user-net: negative overpay = user net win
+                    user_net = -score.adjusted_overpay
+                    h.user_net_ktc += user_net
+                    if user_net > 800:
+                        h.user_wins += 1
+                    elif user_net < -800:
+                        h.user_losses += 1
+                    else:
+                        h.fair += 1
+    except Exception as e:
+        print(f"  (history fetch skipped: {e})")
+
+    # Score each non-user owner
+    scores: list[PartnerScore] = []
+    for roster in rosters:
+        if roster.owner_id == user.user_id:
+            continue
+        owner = user_display.get(str(roster.owner_id), f"Roster {roster.roster_id}")
+        p_arch, p_strong, p_weak = _classify(roster)
+        history = histories.get(roster.roster_id, TradeHistory())
+        scores.append(score_partner(
+            owner=owner,
+            roster_id=roster.roster_id,
+            user_archetype=user_arch,
+            partner_archetype=p_arch,
+            user_strong=user_strong,
+            user_weak=user_weak,
+            partner_strong=p_strong,
+            partner_weak=p_weak,
+            history=history,
+        ))
+
+    ranked = rank_partners(scores)
+    top_n = args.top if hasattr(args, "top") else 12
+
+    print()
+    print("=" * 78)
+    print(f"  TRADE PARTNERS for {args.username} in {league.name}")
+    print(f"  Your archetype: {user_arch}")
+    if user_strong:
+        print(f"  Your strengths:  {', '.join(sorted(user_strong))}")
+    if user_weak:
+        print(f"  Your weaknesses: {', '.join(sorted(user_weak))}")
+    print("=" * 78)
+    print()
+    headers = ["#", "Owner", "Score", "Arch", "Syn", "Pos", "Hist", "Rationale"]
+    rows = []
+    for i, s in enumerate(ranked[:top_n], 1):
+        rows.append([
+            str(i),
+            s.owner[:22],
+            f"{s.total:+d}",
+            s.archetype[:9],
+            f"{s.synergy:+d}",
+            f"{s.positional.score:+d}",
+            f"{s.history_pts:+d}",
+            s.rationale[:60],
+        ])
+    print(_format_table(headers, rows))
+    print()
+    if ranked:
+        top = ranked[0]
+        print(f"🎯 Top engage target: {top.owner} (score {top.total:+d})")
+        print(f"   {top.rationale}")
+
 
 def cmd_proposed_trades(args) -> None:
     """List every pending/proposed trade in the league with KTC valuation.

--- a/python/tests/test_cli_smoke.py
+++ b/python/tests/test_cli_smoke.py
@@ -27,6 +27,7 @@ EXPECTED_SUBCOMMANDS = [
     "send-trade",
     "gm-mode",
     "proposed-trades",   # added May 2026
+    "trade-partners",    # added May 2026
 ]
 
 

--- a/python/tests/test_partner_match.py
+++ b/python/tests/test_partner_match.py
@@ -1,0 +1,242 @@
+"""Tests for analytics.partner_match.
+
+Covers archetype synergy lookups, positional fit overlap math, history
+scoring boundaries, and end-to-end `score_partner` rationale rendering.
+"""
+from __future__ import annotations
+
+import pytest
+
+from sleeper.analytics.partner_match import (
+    PartnerScore,
+    PositionalFit,
+    TradeHistory,
+    archetype_synergy,
+    history_score,
+    positional_fit,
+    rank_partners,
+    score_partner,
+)
+
+
+# ---------------------------------------------------------------------------
+# Archetype synergy
+# ---------------------------------------------------------------------------
+
+def test_rebuilder_loves_contender():
+    """The canonical "best pair" — rebuilder wants contenders to buy vets."""
+    assert archetype_synergy("REBUILDING", "CONTENDER") == 5
+
+
+def test_contender_avoids_other_contender():
+    """Two contenders fight over the same assets — negative synergy."""
+    assert archetype_synergy("CONTENDER", "CONTENDER") == -2
+
+
+def test_pretender_should_sell_to_contender():
+    """Pretender's best move is cashing vets while value is still there."""
+    assert archetype_synergy("PRETENDER", "CONTENDER") == 5
+
+
+def test_unknown_archetype_returns_zero():
+    """Defensive: when gm_mode can't classify, synergy is neutral."""
+    assert archetype_synergy("REBUILDING", "UNKNOWN") == 0
+    assert archetype_synergy("UNKNOWN", "CONTENDER") == 0
+
+
+# ---------------------------------------------------------------------------
+# Positional fit
+# ---------------------------------------------------------------------------
+
+def test_perfect_positional_fit_both_directions():
+    """User QB-strong/RB-weak meets partner RB-strong/QB-weak: both sides win."""
+    fit = positional_fit(
+        user_strong={"QB"},
+        user_weak={"RB"},
+        partner_strong={"RB"},
+        partner_weak={"QB"},
+    )
+    assert fit.user_offers == ["QB"]
+    assert fit.partner_offers == ["RB"]
+    assert fit.score == 4   # 2 + 2
+
+
+def test_no_overlap_returns_zero():
+    """Nothing in common, nothing to trade — score 0."""
+    fit = positional_fit(
+        user_strong={"QB"},
+        user_weak={"WR"},
+        partner_strong={"QB"},   # both strong at QB
+        partner_weak={"WR"},     # both weak at WR
+    )
+    assert fit.user_offers == []
+    assert fit.partner_offers == []
+    assert fit.score == 0
+
+
+def test_one_way_fit_counts():
+    """Only one side has a fit — score 2, not 4."""
+    fit = positional_fit(
+        user_strong={"QB"},
+        user_weak=set(),
+        partner_strong=set(),
+        partner_weak={"QB"},
+    )
+    assert fit.user_offers == ["QB"]
+    assert fit.partner_offers == []
+    assert fit.score == 2
+
+
+def test_multi_position_fit():
+    """Multiple overlaps stack."""
+    fit = positional_fit(
+        user_strong={"QB", "TE"},
+        user_weak={"WR"},
+        partner_strong={"WR"},
+        partner_weak={"QB", "TE"},
+    )
+    assert fit.user_offers == ["QB", "TE"]
+    assert fit.partner_offers == ["WR"]
+    assert fit.score == 6   # 2*2 + 1*2
+
+
+# ---------------------------------------------------------------------------
+# History scoring
+# ---------------------------------------------------------------------------
+
+def test_no_history_gives_small_upside_bonus():
+    """An untapped partner is worth a +1 conversation."""
+    assert history_score(TradeHistory()) == 1
+
+
+def test_three_trades_neutral_ktc_scores_three():
+    """Activity dominates when KTC net is small."""
+    h = TradeHistory(total=3, user_net_ktc=2000)
+    # activity = min(3, 5) = 3, ktc_factor = 2000 // 5000 = 0
+    assert history_score(h) == 3
+
+
+def test_big_positive_ktc_caps_at_three():
+    """A partner who overpays you by 50K KTC caps at +3 contribution."""
+    h = TradeHistory(total=10, user_net_ktc=50000)
+    # activity = 5 (capped), ktc_factor capped at 3
+    assert history_score(h) == 5 + 3   # = 8
+
+
+def test_big_negative_ktc_caps_at_minus_three():
+    """A partner who exploits you caps at −3 contribution (still subject to activity)."""
+    h = TradeHistory(total=10, user_net_ktc=-50000)
+    assert history_score(h) == 5 + (-3)   # = 2
+
+
+def test_one_trade_with_loss_is_punished():
+    """A single bad trade isn't a death sentence but shows up."""
+    h = TradeHistory(total=1, user_net_ktc=-8000)
+    # activity 1, ktc_factor -8000 // 5000 = -2 (floor div in Python is toward -inf)
+    assert history_score(h) == 1 + (-2)   # = -1
+
+
+# ---------------------------------------------------------------------------
+# Score combination + rationale
+# ---------------------------------------------------------------------------
+
+def test_score_partner_combines_three_signals():
+    """The total field is the sum of synergy + positional.score + history_pts."""
+    ps = score_partner(
+        owner="testuser",
+        roster_id=3,
+        user_archetype="REBUILDING",
+        partner_archetype="CONTENDER",
+        user_strong={"QB"},
+        user_weak={"RB"},
+        partner_strong={"RB"},
+        partner_weak={"QB"},
+        history=TradeHistory(total=2, user_net_ktc=6000),
+    )
+    # synergy = 5, positional = 4, history = 2 + 1 = 3 → total 12
+    assert ps.synergy == 5
+    assert ps.positional.score == 4
+    assert ps.history_pts == 3
+    assert ps.total == 12
+
+
+def test_rationale_mentions_offers_when_present():
+    ps = score_partner(
+        owner="u",
+        roster_id=1,
+        user_archetype="REBUILDING",
+        partner_archetype="CONTENDER",
+        user_strong={"QB"},
+        user_weak={"RB"},
+        partner_strong={"RB"},
+        partner_weak={"QB"},
+        history=TradeHistory(),
+    )
+    assert "wants your QB" in ps.rationale
+    assert "has RB you need" in ps.rationale
+    assert "no prior history" in ps.rationale
+
+
+def test_rationale_mentions_history_when_present():
+    ps = score_partner(
+        owner="u",
+        roster_id=1,
+        user_archetype="REBUILDING",
+        partner_archetype="REBUILDING",
+        user_strong=set(),
+        user_weak=set(),
+        partner_strong=set(),
+        partner_weak=set(),
+        history=TradeHistory(total=4, user_net_ktc=10000),
+    )
+    assert "4 prior trades" in ps.rationale
+    assert "+10,000" in ps.rationale
+
+
+# ---------------------------------------------------------------------------
+# Ranking
+# ---------------------------------------------------------------------------
+
+def _make_score(owner: str, total: int, synergy: int = 0, history_pts: int = 0):
+    return PartnerScore(
+        owner=owner,
+        roster_id=1,
+        archetype="REBUILDING",
+        synergy=synergy,
+        positional=PositionalFit(),
+        history=TradeHistory(),
+        history_pts=history_pts,
+        total=total,
+        rationale="",
+    )
+
+
+def test_rank_partners_sorts_by_total_desc():
+    scores = [
+        _make_score("alpha", 3),
+        _make_score("bravo", 8),
+        _make_score("charlie", 5),
+    ]
+    ranked = rank_partners(scores)
+    assert [s.owner for s in ranked] == ["bravo", "charlie", "alpha"]
+
+
+def test_rank_partners_breaks_ties_by_synergy():
+    """When totals tie, higher synergy wins (it's the more durable signal)."""
+    scores = [
+        _make_score("alpha", 5, synergy=1, history_pts=4),
+        _make_score("bravo", 5, synergy=4, history_pts=1),
+    ]
+    ranked = rank_partners(scores)
+    assert ranked[0].owner == "bravo"
+
+
+def test_rank_partners_is_deterministic_for_full_ties():
+    """Final tie-break is alphabetical (case-insensitive) — output stable across runs."""
+    scores = [
+        _make_score("Zeta", 3),
+        _make_score("alpha", 3),
+        _make_score("Beta", 3),
+    ]
+    ranked = rank_partners(scores)
+    assert [s.owner for s in ranked] == ["alpha", "Beta", "Zeta"]


### PR DESCRIPTION
New analysis primitive: ranks every other owner in a league by trade- partner compatibility with the user, combining three signals into one engagement score:

1. Archetype synergy — rebuilders pair with contenders, contenders avoid each other, pretenders should sell to contenders, etc. Encoded explicitly in analytics/partner_match._SYNERGY (-3 to +5).
2. Positional fit — user surplus ↔ partner need overlap; bi-directional matches score higher because they're more transactable.
3. History — past completed trades between the two rosters, weighted by activity (capped) and net KTC swing (capped ±3). Untapped partners get a small "first conversation" bonus.

Output is a ranked table with a one-line rationale per partner suitable for pasting into a DM ("REBUILDING · wants your QB · 4 prior trades (+13,200 net)").

Implementation:
- analytics/partner_match.py — pure scoring functions (synergy, positional_fit, history_score, score_partner, rank_partners). All unit-testable without network or auth.
- cli/analysis.py — cmd_trade_partners orchestrates: lazy-loads gm_mode (same pattern as cmd_gm_mode), classifies each roster, optionally folds in trade history if SLEEPER_TOKEN is set, scores via partner_match, renders ranked table.
- cli/_main.py — argparse + dispatch
- .claude/commands/trade-partners.md — skill doc with triggers, invocations, output interpretation, and follow-up chains
- tests/test_partner_match.py — 20 unit tests covering synergy lookups, fit math, history boundaries, score combination, deterministic ranking
- tests/test_cli_smoke.py — trade-partners added to EXPECTED_SUBCOMMANDS

Auth is optional. Without SLEEPER_TOKEN the history score defaults to the "untapped channel" baseline; with auth, league-wide completed trades are pulled and bucketed by counterpart roster.