### PR TITLE
feat(value-adjustment): v2 model with dilution tax + all-chips isolation

### DIFF
--- a/python/src/sleeper/analytics/value_adjustment.py
+++ b/python/src/sleeper/analytics/value_adjustment.py
@@ -1,24 +1,57 @@
-"""KTC-style Value Adjustment for lopsided trades.
+"""KTC-style Value Adjustment v2.
 
-KeepTradeCut applies a "Value Adjustment" on lopsided trades — extra KTC is
-added to the side giving up more roster spots or more "stud factor". The
-principle (in their words): 12 third-round picks are NOT a fair deal for
-DeAndre Hopkins — the 1-stud side needs compensation for compressing roster
-depth and concentrating production.
+KeepTradeCut's stated principle (from their docs):
 
-This module implements the same principle as a pure function. It's not a
-byte-for-byte reverse of KTC's proprietary formula (not publicly documented),
-but it behaves the same way: lopsided-count + high-stud trades get an
-adjustment that tilts value toward the stud side.
+    "Trading is more than simple addition. We add value to the side of the
+    trade that's giving up more when you look at roster spots, players'
+    'stud' factor, etc. This is our way of countering — as much as
+    possible — trade calculations that say 12 third round picks are a
+    fair deal for DeAndre Hopkins. The actual adjustment is reverse
+    engineered from the player the lesser side needs to have added to
+    even the trade."
+
+This module implements that principle as a pure function. It is not a
+byte-for-byte reverse of KTC's proprietary formula (not public), but it
+behaves the same way: lopsided-count + high-stud trades carry a tax that
+tilts value toward the stud side, scaled by how diluted the filler is.
+
+Four components combine into the adjustment:
+
+1. **Spot premium** — per roster-spot the consolidating side compresses.
+   Scales by the stud's tier (elite > high > mid > none).
+
+2. **Tier scarcity premium** — a percentage of the target's KTC, recognizing
+   that elite assets transact above face value because they're rare.
+
+3. **Isolation gap** — sum of (target − chip) across ALL filler chips below
+   the target, multiplied by tier coefficient. Captures "every chip below
+   the stud compounds the quality compression," not just the top one.
+   (v1 only looked at the top filler chip and missed this completely.)
+
+4. **Dilution penalty** — punishes stacking many low-value chips to reach
+   the target. The market discounts filler-stacking because roster slots
+   are valuable, stud production is multiplicative, and multi-chip trades
+   carry execution risk. Quantifies the "10 third-round picks ≠ DeAndre
+   Hopkins" principle by penalizing the gap between AVG chip value and
+   target value, compounded by chip count.
+
+    dilution = target × (1 − avg/target)^1.5 × (n − 1) × DILUTION_MULT
+
+The 1.5 exponent makes the penalty curve steep at the extremes (low avg
+ratio = severe punishment) but mild for healthy 2-for-1 packages where
+each chip is meaningful on its own.
 
 Usage:
     adj = compute_value_adjustment(
         send_values=[5200, 3100, 1400],
         receive_values=[9800],
     )
-    # => {"adjustment": +1342, "favors": "send", "roster_spot_diff": 2, "top_stud_value": 9800}
+    adjusted_delta = raw_delta - adj.adjustment  # if you're the stud receiver
 
-    adjusted_delta = raw_delta - adj["adjustment"]  # subtract if you're the stud-receiving side
+A note on the "missing piece" idea: KTC reverse-engineers the adjustment
+from the player needed to even the trade. We expose `suggest_evening_piece`
+that maps an adjustment amount back to a human-readable description (≈ a
+2027 Mid 1st, ≈ a low-end RB1, etc.) so the same intuition surfaces.
 """
 from __future__ import annotations
 
@@ -26,48 +59,80 @@ from dataclasses import dataclass
 from typing import Literal
 
 
-# Stud-factor thresholds — above these KTC values the player counts as a true
-# positional stud and justifies extra compensation.
+# ---------------------------------------------------------------------------
+# Stud-factor thresholds
+# ---------------------------------------------------------------------------
+
 STUD_TIER_ELITE = 8000      # Top-3 positional (Chase, Bijan, Allen)
 STUD_TIER_HIGH = 6000       # Top-6 positional (WR1, RB1)
 STUD_TIER_MID = 4000        # Top-12 positional (WR/RB1 borderline)
 
-# Per-roster-spot value added to the stud side for each extra player sent
-# by the non-stud side. Scales with the tier of the top player in the trade.
-# Tuned 2026-05: prior values (600/400/250) systematically undervalued elite-tier
-# consolidation by ~3x relative to actual market behavior. Real consolidation
-# trades for top-12 WR/RB require 2-3K KTC of premium, not 600-750.
+
+# ---------------------------------------------------------------------------
+# Per-roster-spot premium
+# ---------------------------------------------------------------------------
+
 SPOT_VALUE_ELITE = 1500
 SPOT_VALUE_HIGH = 1000
 SPOT_VALUE_MID = 600
 SPOT_VALUE_BASE = 200
 
-# Tier premium — a percentage of the target's KTC added when the receive side
-# acquires an elite/high-tier asset. Captures the scarcity premium that elite
-# young WR1/RB1 command above raw KTC face value.
-TIER_PREMIUM_ELITE = 0.30   # 30% of target KTC for elite (8000+)
-TIER_PREMIUM_HIGH = 0.18    # 18% of target KTC for high (6000-7999)
-TIER_PREMIUM_MID = 0.08     # 8% for mid (4000-5999)
 
-# Quality-gap penalty multiplier — when the best single asset on the send side
-# is materially smaller than the target, an additional premium is owed for the
-# quality compression. Multiplies (target - top_send) by this factor.
-QUALITY_GAP_MULT_ELITE = 0.40
-QUALITY_GAP_MULT_HIGH = 0.25
-QUALITY_GAP_MULT_MID = 0.10
+# ---------------------------------------------------------------------------
+# Tier scarcity premium — % of target KTC (the "they're rare" tax)
+# ---------------------------------------------------------------------------
+
+TIER_PREMIUM_ELITE = 0.30
+TIER_PREMIUM_HIGH = 0.18
+TIER_PREMIUM_MID = 0.08
+
+
+# ---------------------------------------------------------------------------
+# Isolation gap — sum over ALL filler chips of (target − chip), × multiplier.
+# v1's quality_gap only looked at the top filler chip; v2 sums every chip
+# that's below the target so a 5-filler package compounds, not just the best.
+# ---------------------------------------------------------------------------
+
+ISOLATION_GAP_MULT_ELITE = 0.25
+ISOLATION_GAP_MULT_HIGH = 0.18
+ISOLATION_GAP_MULT_MID = 0.08
+
+
+# ---------------------------------------------------------------------------
+# Dilution penalty — the "10 shit players ≠ 1 elite" tax.
+# Scales with chip count AND how low-quality the average chip is.
+# ---------------------------------------------------------------------------
+
+DILUTION_MULT = 0.20
+DILUTION_EXPONENT = 1.5   # curve steepness; > 1 means low avg ratios hurt more
+
+
+# ---------------------------------------------------------------------------
+# Output dataclass
+# ---------------------------------------------------------------------------
 
 
 @dataclass
 class ValueAdjustment:
-    adjustment: int                    # KTC to add to the stud side
+    adjustment: int                        # KTC owed to the stud side
     favors: Literal["send", "receive", "none"]
-    roster_spot_diff: int              # positive = receive side sent more bodies
-    top_stud_value: int                # KTC of the largest single asset in the trade
+    roster_spot_diff: int                  # positive = receive side sent more bodies
+    top_stud_value: int                    # KTC of the largest single asset in the trade
     stud_tier: Literal["elite", "high", "mid", "none"]
-    rationale: str
+    spot_component: int = 0                # per-spot premium contribution
+    tier_premium: int = 0                  # scarcity premium contribution
+    isolation_gap: int = 0                 # sum-of-gaps contribution
+    dilution: int = 0                      # avg-value-per-asset tax
+    rationale: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
 
 
 def _stud_tier(ktc: int) -> tuple[str, int]:
+    """Return (tier_name, per_spot_value) for a player's KTC."""
     if ktc >= STUD_TIER_ELITE:
         return "elite", SPOT_VALUE_ELITE
     if ktc >= STUD_TIER_HIGH:
@@ -78,11 +143,7 @@ def _stud_tier(ktc: int) -> tuple[str, int]:
 
 
 def _tier_premium(target_ktc: int, tier: str) -> int:
-    """Scarcity premium owed to the side acquiring an elite/high tier asset.
-
-    Elite young WR1/RB1 transact at 15-30% above raw KTC face value because
-    they're rare and consolidating. Captured here as a flat % of target KTC.
-    """
+    """Scarcity premium — % of target KTC by tier."""
     if tier == "elite":
         return int(target_ktc * TIER_PREMIUM_ELITE)
     if tier == "high":
@@ -92,23 +153,62 @@ def _tier_premium(target_ktc: int, tier: str) -> int:
     return 0
 
 
-def _quality_gap_penalty(top_send: int, top_recv: int, tier: str) -> int:
-    """Premium owed when the best single chip is materially below the target.
+def _isolation_gap(filler_values: list[int], target_ktc: int, tier: str) -> int:
+    """Sum of (target − chip) for every filler chip BELOW the target.
 
-    A 4,888 chip going for a 9,910 target leaves a 5,022 quality gap — the
-    receive side is concentrating value the send side can't match in any
-    single asset. Penalty scales with gap size and target tier.
+    v2 change: this used to only consider the top filler chip
+    (`max(filler_values)`). A 4K + 4K + 4K package for a 10K stud only got
+    penalized for the 6K gap on the top chip — the other two chips were
+    "free." Now every below-target chip's gap contributes, which is what
+    captures the "many small chips compound the quality compression"
+    intuition.
     """
-    if top_recv <= 0 or top_send >= top_recv:
+    if target_ktc <= 0 or not filler_values:
         return 0
-    gap = top_recv - top_send
+    total_gap = sum(max(0, target_ktc - v) for v in filler_values)
     if tier == "elite":
-        return int(gap * QUALITY_GAP_MULT_ELITE)
+        return int(total_gap * ISOLATION_GAP_MULT_ELITE)
     if tier == "high":
-        return int(gap * QUALITY_GAP_MULT_HIGH)
+        return int(total_gap * ISOLATION_GAP_MULT_HIGH)
     if tier == "mid":
-        return int(gap * QUALITY_GAP_MULT_MID)
+        return int(total_gap * ISOLATION_GAP_MULT_MID)
     return 0
+
+
+def _dilution_penalty(filler_values: list[int], target_ktc: int) -> int:
+    """The "10 shit players ≠ 1 elite player" tax.
+
+    Punishes stacking many low-value chips to reach a target. Driven by:
+
+      avg_ratio = avg(filler) / target_ktc       # how good is the avg chip?
+      shortfall = max(0, 1 − avg_ratio)          # how far from target on avg?
+      penalty   = target × shortfall^1.5 × (n − 1) × DILUTION_MULT
+
+    Properties:
+      - 1-for-1: returns 0 (n − 1 = 0)
+      - avg ≥ target: returns 0 (shortfall = 0)
+      - avg ≈ target / 2 with 2 chips: small penalty
+      - avg ≈ target / 10 with 10 chips: large penalty (the canonical case)
+
+    The 1.5 exponent gives a steep curve: severe punishment for genuinely
+    diluted packages, mild for balanced 2-for-1s where each chip is real.
+    """
+    if target_ktc <= 0 or not filler_values:
+        return 0
+    n = len(filler_values)
+    if n <= 1:
+        return 0
+    avg = sum(filler_values) / n
+    if avg >= target_ktc:
+        return 0
+    shortfall = 1.0 - (avg / target_ktc)
+    curve = shortfall ** DILUTION_EXPONENT
+    return int(target_ktc * curve * (n - 1) * DILUTION_MULT)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 def compute_value_adjustment(
@@ -122,18 +222,14 @@ def compute_value_adjustment(
         receive_values: KTC values of assets joining your roster.
 
     Returns:
-        ValueAdjustment describing the adjustment + which side it favors.
+        ValueAdjustment with the total + per-component breakdown.
 
-    The adjustment is ALWAYS positive (or zero). It represents extra KTC
-    that should be added to the side giving up fewer roster spots (the
-    "stud side") to compensate them for the roster-depth loss on the
-    other side.
+    The adjustment is ALWAYS non-negative. It represents extra KTC the
+    side acquiring the concentrated value (the "stud side") owes ON TOP
+    of face value to fairly land the deal.
     """
     n_send = len(send_values)
     n_recv = len(receive_values)
-
-    # Roster-spot differential: positive means receive side is sending more
-    # bodies (i.e. YOU are sending fewer = you're the stud side).
     spot_diff = abs(n_send - n_recv)
 
     if spot_diff == 0:
@@ -148,8 +244,6 @@ def compute_value_adjustment(
             rationale="Even roster-spot count — no adjustment.",
         )
 
-    # The "stud" is the largest single asset in the trade. Their tier sets
-    # the per-spot value.
     all_values = send_values + receive_values
     if not all_values:
         return ValueAdjustment(
@@ -157,56 +251,48 @@ def compute_value_adjustment(
             top_stud_value=0, stud_tier="none",
             rationale="Empty trade.",
         )
+
     top_stud = max(all_values)
     tier, spot_value = _stud_tier(top_stud)
 
-    # Who has the stud? Whoever is SENDING fewer bodies is the stud side
-    # (they're consolidating value; the other side is filling with filler).
+    # The "stud side" is whoever sends FEWER bodies (consolidates value).
     if n_send < n_recv:
-        # YOU are sending 1 (the stud) for many -> adjustment favors SEND side
         favors = "send"
         stud_side_desc = "send"
         filler_side_desc = "receive"
+        filler_values = receive_values
     else:
-        # YOU are receiving 1 (the stud) for many -> adjustment favors RECEIVE side
         favors = "receive"
         stud_side_desc = "receive"
         filler_side_desc = "send"
+        filler_values = send_values
 
+    target_ktc = max(receive_values) if favors == "receive" else max(send_values)
+
+    # 1. Spot premium — per roster-spot, scaled by tier
     spot_component = spot_diff * spot_value
-
-    # Additional "stud factor" bonus — being a true elite asset carries
-    # extra weight beyond the per-spot math.
     if tier == "elite":
         spot_component = int(spot_component * 1.25)
     elif tier == "high":
         spot_component = int(spot_component * 1.10)
 
-    # Tier scarcity premium — % of target KTC. Only applies when the stud
-    # is on the receive side (i.e. someone is acquiring concentrated value).
-    # Symmetric: also applies when stud is on send side (someone consolidates
-    # to land them — roles reversed but the premium is the same magnitude).
-    target_ktc = max(receive_values) if favors == "receive" else max(send_values)
+    # 2. Tier scarcity premium
     tier_prem = _tier_premium(target_ktc, tier)
 
-    # Quality-gap penalty — how far below the target is the best single chip
-    # on the filler side?
-    if favors == "receive":
-        # Send side is the filler side
-        top_filler = max(send_values) if send_values else 0
-        top_target = max(receive_values) if receive_values else 0
-    else:
-        # Receive side is the filler side
-        top_filler = max(receive_values) if receive_values else 0
-        top_target = max(send_values) if send_values else 0
-    quality_gap = _quality_gap_penalty(top_filler, top_target, tier)
+    # 3. Isolation gap (sum of all filler chips below target × tier multiplier)
+    isolation = _isolation_gap(filler_values, target_ktc, tier)
 
-    adjustment = spot_component + tier_prem + quality_gap
+    # 4. Dilution penalty (the "many small chips ≠ one stud" tax)
+    dilution = _dilution_penalty(filler_values, target_ktc)
+
+    adjustment = spot_component + tier_prem + isolation + dilution
 
     rationale = (
-        f"{stud_side_desc.capitalize()} side sent 1 stud (KTC {top_stud:,}, {tier} tier); "
-        f"{filler_side_desc} side sent {spot_diff} extra roster spots of filler. "
-        f"Spot: +{spot_component:,}, tier premium: +{tier_prem:,}, quality gap: +{quality_gap:,}. "
+        f"{stud_side_desc.capitalize()} side has the stud (KTC {top_stud:,}, "
+        f"{tier} tier); {filler_side_desc} side compresses {spot_diff} extra "
+        f"roster spot(s) of filler. "
+        f"Spot: +{spot_component:,}, tier premium: +{tier_prem:,}, "
+        f"isolation gap: +{isolation:,}, dilution tax: +{dilution:,}. "
         f"Total adjustment: +{adjustment:,} to the {stud_side_desc} side."
     )
 
@@ -216,6 +302,10 @@ def compute_value_adjustment(
         roster_spot_diff=spot_diff,
         top_stud_value=top_stud,
         stud_tier=tier,  # type: ignore[arg-type]
+        spot_component=spot_component,
+        tier_premium=tier_prem,
+        isolation_gap=isolation,
+        dilution=dilution,
         rationale=rationale,
     )
 
@@ -225,31 +315,75 @@ def apply_adjustment_to_delta(
     send_values: list[int],
     receive_values: list[int],
 ) -> tuple[int, ValueAdjustment]:
-    """Apply value adjustment from the 'send' side's perspective.
+    """Apply the value adjustment from the user's perspective.
 
     Args:
-        raw_delta: receive_total - send_total (positive = you win on raw KTC)
-        send_values: what you're sending
-        receive_values: what you're receiving
+        raw_delta: receive_total − send_total (positive = user "wins" on raw KTC)
+        send_values: what the user is sending
+        receive_values: what the user is receiving
 
     Returns:
         (adjusted_delta, ValueAdjustment)
 
-    The adjusted_delta accounts for the stud-factor: if you're receiving
-    the stud (favors="receive"), the adjustment INCREASES the effective
-    cost to you (adjusted_delta goes DOWN). If you're sending the stud
-    (favors="send"), the adjustment makes the trade MORE favorable to
-    you (adjusted_delta goes UP).
+    If the user is RECEIVING the stud (favors="receive"), the adjustment
+    is owed ON TOP of face value — subtract from the delta (worse for you).
+    If the user is SENDING the stud (favors="send"), the partner owes the
+    premium — add to the delta (better for you).
     """
     adj = compute_value_adjustment(send_values, receive_values)
 
     if adj.favors == "receive":
-        # You're getting the stud — pay extra value adjustment
         adjusted = raw_delta - adj.adjustment
     elif adj.favors == "send":
-        # You're sending the stud — get credit for extra value adjustment
         adjusted = raw_delta + adj.adjustment
     else:
         adjusted = raw_delta
 
     return adjusted, adj
+
+
+# ---------------------------------------------------------------------------
+# "Missing piece" — reverse-engineer KTC's hint: "what would even the trade?"
+# ---------------------------------------------------------------------------
+
+# Rough KTC tiers for picks and player asset bands — used to translate an
+# adjustment amount back into a human-readable "what would balance this?"
+# string. Values are intentionally fuzzy bands; the labels are the point.
+_PIECE_BANDS: tuple[tuple[int, str], ...] = (
+    (    250, "a throw-in (rookie taxi piece)"),
+    (    750, "a deep bench flier"),
+    (   1500, "a late 2nd-round rookie pick"),
+    (   2200, "a 2027 2nd"),
+    (   3000, "a 2026 2nd"),
+    (   3800, "a 2027 Mid 1st"),
+    (   4800, "a 2026 Mid 1st"),
+    (   6000, "a low-end WR2 / RB2"),
+    (   7500, "a high-end WR2 / RB2"),
+    (   9500, "a fringe WR1 / RB1"),
+    (  12000, "an elite WR1 / RB1"),
+)
+
+
+def suggest_evening_piece(adjustment: int) -> str:
+    """Translate an adjustment amount into a human-readable "missing piece".
+
+    Inspired by KTC's framing — the adjustment is the value the lesser
+    side would need to add to even the trade. Mapping that number back to
+    a recognizable asset ("≈ a 2027 Mid 1st") makes the math actionable
+    in a DM.
+
+    Returns a short phrase suitable for inline rendering:
+
+        >>> suggest_evening_piece(4800)
+        '≈ a 2026 Mid 1st'
+        >>> suggest_evening_piece(150)
+        '≈ a throw-in'
+        >>> suggest_evening_piece(15000)
+        '≈ a stud-tier asset (12K+ KTC)'
+    """
+    if adjustment <= 0:
+        return "≈ already balanced"
+    for ceiling, label in _PIECE_BANDS:
+        if adjustment <= ceiling:
+            return f"≈ {label}"
+    return "≈ a stud-tier asset (12K+ KTC)"

--- a/python/tests/test_value_adjustment.py
+++ b/python/tests/test_value_adjustment.py
@@ -1,21 +1,24 @@
-"""Tests for analytics.value_adjustment.
+"""Tests for analytics.value_adjustment (v2 model).
 
 Coverage:
 - Empty / degenerate cases
 - Even-spot trades produce zero adjustment
 - Tier classification (elite / high / mid / none)
-- Spot premium scaling with tier
-- Tier scarcity premium (% of target KTC)
-- Quality-gap penalty when top send chip is far below target
+- Spot premium scales with tier
+- Tier scarcity premium = % of target KTC
+- Isolation gap considers ALL filler chips (not just top)
+- Dilution penalty quantifies "10 shit players ≠ 1 elite"
 - Sign correctness for `apply_adjustment_to_delta`
-- Regression tests for the May 2026 tuning + sign fix
+- Regression tests for the May 2026 sign-fix
+- suggest_evening_piece — reverse-engineered "missing piece" label
 """
 from __future__ import annotations
 
 import pytest
 
 from sleeper.analytics.value_adjustment import (
-    QUALITY_GAP_MULT_ELITE,
+    DILUTION_MULT,
+    ISOLATION_GAP_MULT_ELITE,
     SPOT_VALUE_BASE,
     SPOT_VALUE_ELITE,
     STUD_TIER_ELITE,
@@ -26,6 +29,7 @@ from sleeper.analytics.value_adjustment import (
     TIER_PREMIUM_MID,
     apply_adjustment_to_delta,
     compute_value_adjustment,
+    suggest_evening_piece,
 )
 
 
@@ -55,7 +59,7 @@ def test_2_for_2_returns_zero_adjustment():
 
 
 # ---------------------------------------------------------------------------
-# Tier classification — verifies the boundary thresholds match the constants
+# Tier classification
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("ktc,expected_tier", [
@@ -69,13 +73,12 @@ def test_2_for_2_returns_zero_adjustment():
 ])
 def test_tier_classification(ktc, expected_tier):
     """Top stud's KTC determines the tier; verify each threshold."""
-    # Provide an even trade so adjustment is 0 but tier is reported.
     adj = compute_value_adjustment(send_values=[ktc], receive_values=[1])
     assert adj.stud_tier == expected_tier
 
 
 # ---------------------------------------------------------------------------
-# Spot premium component
+# Spot premium
 # ---------------------------------------------------------------------------
 
 def test_2_for_1_with_elite_stud_uses_elite_spot_value():
@@ -84,13 +87,10 @@ def test_2_for_1_with_elite_stud_uses_elite_spot_value():
         send_values=[10000],
         receive_values=[3000, 3000],
     )
-    # favors=send because send has 1 chip = the stud side
     assert adj.favors == "send"
     assert adj.roster_spot_diff == 1
-    # spot premium = SPOT_VALUE_ELITE * 1.25 (elite multiplier)
     expected_spot = int(SPOT_VALUE_ELITE * 1 * 1.25)
-    # Plus tier premium and (possibly) quality gap on top
-    assert adj.adjustment >= expected_spot
+    assert adj.spot_component == expected_spot
 
 
 def test_2_for_1_with_no_stud_uses_base_spot_value():
@@ -100,8 +100,7 @@ def test_2_for_1_with_no_stud_uses_base_spot_value():
         receive_values=[1000, 800],
     )
     assert adj.stud_tier == "none"
-    # Should use SPOT_VALUE_BASE without tier scaling
-    assert adj.adjustment == SPOT_VALUE_BASE
+    assert adj.spot_component == SPOT_VALUE_BASE
 
 
 # ---------------------------------------------------------------------------
@@ -109,74 +108,131 @@ def test_2_for_1_with_no_stud_uses_base_spot_value():
 # ---------------------------------------------------------------------------
 
 def test_elite_target_carries_30pct_tier_premium():
-    """Receiving an elite (8000+) stud adds 30% of target KTC as tier premium."""
     target = 10000
     adj = compute_value_adjustment(
-        send_values=[3000, 3000],   # filler side
+        send_values=[3000, 3000],
         receive_values=[target],
     )
     assert adj.favors == "receive"
     assert adj.stud_tier == "elite"
-    # adjustment should include >= 30% of target as tier premium component
-    expected_tier_prem = int(target * TIER_PREMIUM_ELITE)
-    assert adj.adjustment >= expected_tier_prem
+    assert adj.tier_premium == int(target * TIER_PREMIUM_ELITE)
 
 
 def test_high_target_carries_18pct_tier_premium():
-    target = 7000  # high tier
+    target = 7000
     adj = compute_value_adjustment(
         send_values=[3000, 2500],
         receive_values=[target],
     )
     assert adj.stud_tier == "high"
-    expected_tier_prem = int(target * TIER_PREMIUM_HIGH)
-    assert adj.adjustment >= expected_tier_prem
+    assert adj.tier_premium == int(target * TIER_PREMIUM_HIGH)
 
 
 def test_mid_target_carries_8pct_tier_premium():
-    target = 5000  # mid tier
+    target = 5000
     adj = compute_value_adjustment(
         send_values=[2000, 1500],
         receive_values=[target],
     )
     assert adj.stud_tier == "mid"
-    expected_tier_prem = int(target * TIER_PREMIUM_MID)
-    assert adj.adjustment >= expected_tier_prem
+    assert adj.tier_premium == int(target * TIER_PREMIUM_MID)
 
 
 # ---------------------------------------------------------------------------
-# Quality-gap penalty
+# Isolation gap — every chip below target compounds (v2 change)
 # ---------------------------------------------------------------------------
 
-def test_quality_gap_penalty_for_elite_target_with_weak_filler():
-    """When best send chip is far below an elite target, gap penalty applies."""
+def test_isolation_gap_sums_all_filler_chips_not_just_top():
+    """The v2 isolation_gap considers EVERY chip below target.
+
+    Old v1 quality_gap was max(0, target - top_send) × mult — a chip pack
+    of [9K, 1K, 1K] for 10K target only penalized the 1K gap on top chip.
+    v2 sums (10K-9K) + (10K-1K) + (10K-1K) = 19K of gap.
+    """
     target = 10000
-    weak_top = 2000   # large gap
-    decent_top = 8000   # small gap
-    adj_weak = compute_value_adjustment(
-        send_values=[weak_top, 1500],
-        receive_values=[target],
-    )
-    adj_decent = compute_value_adjustment(
-        send_values=[decent_top, 1500],
-        receive_values=[target],
-    )
-    # Bigger gap => bigger adjustment
-    assert adj_weak.adjustment > adj_decent.adjustment
-
-
-def test_quality_gap_zero_when_top_send_meets_target():
-    """No gap penalty when send side already has a chip ≥ target KTC."""
     adj = compute_value_adjustment(
-        send_values=[10000, 1000],
+        send_values=[9000, 1000, 1000],
+        receive_values=[target],
+    )
+    expected_gap = ((target - 9000) + (target - 1000) + (target - 1000))
+    expected_iso = int(expected_gap * ISOLATION_GAP_MULT_ELITE)
+    assert adj.isolation_gap == expected_iso
+
+
+def test_isolation_gap_ignores_chips_above_target():
+    """A chip ABOVE target contributes nothing to the gap — only below counts."""
+    target = 5000
+    adj = compute_value_adjustment(
+        send_values=[8000, 1000],   # 8000 is above 5000, ignore for gap
+        receive_values=[target],
+    )
+    expected_gap = target - 1000   # only the 1000 chip
+    expected_iso = int(expected_gap * ISOLATION_GAP_MULT_ELITE)
+    assert adj.isolation_gap == expected_iso
+
+
+def test_quality_gap_zero_when_all_chips_meet_target():
+    adj = compute_value_adjustment(
+        send_values=[10000, 11000],
         receive_values=[8500],
     )
-    # Top send (10000) >= target (8500) -> gap penalty is 0
-    # adjustment should equal spot premium + tier premium (no gap)
-    spot = int(SPOT_VALUE_ELITE * 1 * 1.25)
-    tier_prem = int(8500 * TIER_PREMIUM_ELITE)
-    expected = spot + tier_prem
-    assert adj.adjustment == expected
+    assert adj.isolation_gap == 0
+
+
+# ---------------------------------------------------------------------------
+# Dilution penalty — the v2 headline feature
+# ---------------------------------------------------------------------------
+
+def test_dilution_is_zero_for_one_for_one():
+    """A 1-for-1 trade has no dilution by definition."""
+    adj = compute_value_adjustment(send_values=[5000], receive_values=[9000])
+    assert adj.dilution == 0
+
+
+def test_dilution_is_zero_when_avg_meets_target():
+    """If avg chip value is at the target, nothing is diluted."""
+    target = 5000
+    adj = compute_value_adjustment(
+        send_values=[5000, 5000, 5000],
+        receive_values=[target],
+    )
+    assert adj.dilution == 0
+
+
+def test_dilution_grows_with_chip_count():
+    """Same avg ratio but more chips => more dilution tax."""
+    target = 10000
+    # 2 chips at 2K each = 1/5 ratio, 1 extra spot
+    adj_2 = compute_value_adjustment(send_values=[2000, 2000], receive_values=[target])
+    # 5 chips at 2K each = 1/5 ratio, 4 extra spots — should hurt much more
+    adj_5 = compute_value_adjustment(
+        send_values=[2000, 2000, 2000, 2000, 2000],
+        receive_values=[target],
+    )
+    assert adj_5.dilution > adj_2.dilution * 2   # noticeably more than linear
+
+
+def test_dilution_grows_as_avg_drops():
+    """Same chip count but lower avg => more dilution tax."""
+    target = 10000
+    # 2 chips at 4K each — avg is 40% of target
+    adj_mid = compute_value_adjustment(send_values=[4000, 4000], receive_values=[target])
+    # 2 chips at 500 each — avg is 5% of target
+    adj_low = compute_value_adjustment(send_values=[500, 500], receive_values=[target])
+    assert adj_low.dilution > adj_mid.dilution
+
+
+def test_ten_filler_chips_for_elite_pays_massive_dilution():
+    """The canonical KTC case: many filler ≠ one elite. Must hurt a lot."""
+    target = 10000
+    adj = compute_value_adjustment(
+        send_values=[1000] * 10,
+        receive_values=[target],
+    )
+    # Dilution alone should exceed a 2026 mid 1st (~4800 KTC)
+    assert adj.dilution > 4800
+    # And the TOTAL adjustment should make this trade WILDLY unfair
+    assert adj.adjustment > 20000
 
 
 # ---------------------------------------------------------------------------
@@ -185,7 +241,7 @@ def test_quality_gap_zero_when_top_send_meets_target():
 
 def test_apply_adjustment_receive_stud_lowers_adjusted_delta():
     """If you receive the stud, the adjustment makes the trade WORSE for you."""
-    raw_delta = 1000   # you "win" 1000 on raw
+    raw_delta = 1000
     adjusted, adj = apply_adjustment_to_delta(
         raw_delta=raw_delta,
         send_values=[3000, 2500],
@@ -198,7 +254,7 @@ def test_apply_adjustment_receive_stud_lowers_adjusted_delta():
 
 def test_apply_adjustment_send_stud_raises_adjusted_delta():
     """If you send the stud, the adjustment makes the trade BETTER for you."""
-    raw_delta = -1000   # you "lose" 1000 on raw
+    raw_delta = -1000
     adjusted, adj = apply_adjustment_to_delta(
         raw_delta=raw_delta,
         send_values=[8500],
@@ -221,95 +277,106 @@ def test_apply_adjustment_even_spots_returns_raw_delta():
 
 
 # ---------------------------------------------------------------------------
-# Regression tests for the May 2026 tuning fix
+# Regression tests
 # ---------------------------------------------------------------------------
 
 def test_regression_fannin_mayfield_for_jsn_needs_substantial_extra_value():
     """User intuition: Fannin + Mayfield-discount → JSN should need a 1st+2nd.
 
-    Combined effect: the QB age discount in find-trades shaves ~2,120 KTC
-    off Mayfield's face (4,709 -> 2,589). On top of that, this test checks
-    that compute_value_adjustment alone reports a deficit > one 1st pick
-    (~5K) — i.e. you owe at LEAST a first to land JSN, on top of the
-    aging-QB discount.
-
-    Combined "true gap" Cam owes vs. face KTC ≈ Mayfield discount + |adj
-    overpay| ≈ 2,120 + 4,400 ≈ 6,500 KTC ≈ 2027 1st + 2027 2nd.
+    With v2 (dilution + all-chips isolation), the adjusted delta should
+    sit in a "needs ≈ a 2026 1st + some change" range.
     """
     fannin = 4881
-    mayfield_discounted = 2589   # 4709 * 0.55 (age 31)
+    mayfield_discounted = 2589
     jsn = 9917
 
-    raw_delta = jsn - (fannin + mayfield_discounted)   # = 2447 (positive: cam wins raw)
+    raw_delta = jsn - (fannin + mayfield_discounted)   # = +2447 (cam wins raw)
     adjusted, adj = apply_adjustment_to_delta(
         raw_delta=raw_delta,
         send_values=[fannin, mayfield_discounted],
         receive_values=[jsn],
     )
     assert adj.favors == "receive"
-    # After stud premium, cam owes a meaningful chunk of additional value —
-    # at least the value of one rookie 2027 1st (~4K), but not so much that
-    # it's wildly out of band (capped at ~7K to catch over-tuning regressions).
-    assert -7000 <= adjusted <= -3500, (
-        f"Expected adjusted delta in [-7000, -3500] (≈1st owed on top of the "
-        f"implicit Mayfield discount), got {adjusted}"
+    # v2 model produces a deeper deficit than v1 — match the new range.
+    assert -10000 <= adjusted <= -3500, (
+        f"Expected adjusted delta in [-10000, -3500] for Fannin+Mayfield→JSN, got {adjusted}"
     )
 
 
-def test_regression_scrub_package_for_elite_stud_is_not_fair():
+def test_regression_scrub_package_for_elite_stud_is_clearly_unfair():
     """Sending only weak filler for an elite stud must NOT score as fair.
 
-    Pre-tuning bug: the algorithm would credit a large stud premium that
-    offset the raw deficit, making 2K-of-scrub-for-10K-elite score like
-    a fair small overpay. After the May 2026 fix, the adjusted delta
-    should be deeply negative (the trade isn't anywhere near fair).
+    The raw delta is +7700 (you "win" the face value swap), but the
+    adjustment should make the effective delta deeply negative because
+    the trade would never transact at this ratio.
     """
-    target = 10000   # elite RB1
-    scrub_a = 700
-    scrub_b = 1600
-
-    raw_delta = target - (scrub_a + scrub_b)   # +7700, you "win" raw
+    target = 10000
+    raw_delta = target - (700 + 1600)   # +7700
     adjusted, adj = apply_adjustment_to_delta(
         raw_delta=raw_delta,
-        send_values=[scrub_a, scrub_b],
+        send_values=[700, 1600],
         receive_values=[target],
     )
-    # After premium, you should still be "winning" raw — but the trade
-    # is so wildly underpriced it would never transact. Premium should
-    # at LEAST eat most of the raw win, leaving < 0 effective.
-    assert adjusted < 0, (
-        f"Scrub-for-elite must net negative after premium; got {adjusted}"
+    # v2 should make this clearly negative — at minimum -1000
+    assert adjusted < -1000, (
+        f"Scrub-for-elite must net deeply negative after v2 premium; got {adjusted}"
     )
 
 
-def test_regression_premium_grows_with_quality_gap():
-    """Same target, weaker filler => bigger premium owed."""
-    target = 9000
-    _, adj_weak = apply_adjustment_to_delta(
-        raw_delta=0,
-        send_values=[1000, 500],   # huge gap
+def test_regression_ten_for_one_makes_3rd_round_for_hopkins_a_joke():
+    """The KTC docs example: 12 third-round picks ≠ DeAndre Hopkins.
+
+    Stand in: Hopkins-tier asset at 7500 KTC vs ten 800 KTC picks.
+    With v2, this MUST score as deeply unfair (massive negative delta).
+    """
+    target = 7500
+    raw_delta = target - (800 * 10)   # = -500 (filler totals more than face)
+    adjusted, adj = apply_adjustment_to_delta(
+        raw_delta=raw_delta,
+        send_values=[800] * 10,
         receive_values=[target],
     )
-    _, adj_strong = apply_adjustment_to_delta(
-        raw_delta=0,
-        send_values=[7000, 2000],   # small gap
-        receive_values=[target],
+    # v2 must punish this severely — needs many thousands MORE in value
+    assert adjusted < -10000, (
+        f"12-for-1 filler-for-Hopkins must be clearly unfair; got {adjusted}"
     )
-    assert adj_weak.adjustment > adj_strong.adjustment
+
+
+# ---------------------------------------------------------------------------
+# suggest_evening_piece — KTC-style missing piece
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("amount,expected_keyword", [
+    (0, "balanced"),
+    (200, "throw-in"),
+    (1400, "2nd-round rookie"),
+    (4500, "Mid 1st"),
+    (7000, "WR2 / RB2"),
+    (50000, "stud-tier"),
+])
+def test_suggest_evening_piece_returns_recognizable_label(amount, expected_keyword):
+    out = suggest_evening_piece(amount)
+    assert expected_keyword in out
+
+
+def test_suggest_evening_piece_handles_negative_input():
+    assert "balanced" in suggest_evening_piece(-500)
 
 
 # ---------------------------------------------------------------------------
 # ValueAdjustment dataclass surface
 # ---------------------------------------------------------------------------
 
-def test_value_adjustment_includes_rationale():
+def test_value_adjustment_breakdown_fields_populated():
     adj = compute_value_adjustment(
         send_values=[3000, 2000],
         receive_values=[8500],
     )
-    assert adj.rationale != ""
-    assert "tier premium" in adj.rationale
-    assert "quality gap" in adj.rationale
+    # Components sum to total
+    assert (
+        adj.spot_component + adj.tier_premium + adj.isolation_gap + adj.dilution
+        == adj.adjustment
+    )
 
 
 def test_value_adjustment_top_stud_value_is_max_of_all():
@@ -318,3 +385,12 @@ def test_value_adjustment_top_stud_value_is_max_of_all():
         receive_values=[5000, 4000],
     )
     assert adj.top_stud_value == 9500
+
+
+def test_rationale_mentions_all_four_components():
+    adj = compute_value_adjustment(
+        send_values=[3000, 2000],
+        receive_values=[8500],
+    )
+    for word in ("Spot", "tier premium", "isolation gap", "dilution"):
+        assert word in adj.rationale


### PR DESCRIPTION
KTC's stated principle is that the value adjustment exists to counter calculations like "12 third round picks = DeAndre Hopkins" — the single-stud side compresses roster spots and concentrates production, so the consolidating side owes a tax that's reverse-engineered from "the piece you'd need to add to even the trade."

v1's math captured part of this (spot premium + tier premium + a top-chip quality gap) but had two material gaps:

1. The quality gap only considered the TOP filler chip. A package of [9K, 1K, 1K, 1K, 1K] for a 10K stud got penalized for the 1K gap on the top chip, and the other four chips were "free" — exactly the opposite of what the KTC docs describe.

2. There was no tax for the "many small chips" pattern at all. Two chips at 5K avg vs ten chips at 1K avg produced very similar adjustments even though one is a real consolidation trade and the other is filler-stacking.

This commit ships:

* **Isolation gap** (replaces v1 quality_gap): sums (target − chip) across EVERY filler chip below the target, multiplied by tier coefficient. Now [9K, 1K, 1K, 1K, 1K] vs 10K gets credit for the ~36K of compounded gap, not just the top chip's 1K.

* **Dilution penalty** (new component): the headline v2 feature. Quantifies "10 third-round picks ≠ Hopkins" by punishing the avg chip value vs target, compounded by chip count:

      dilution = target × (1 − avg/target)^1.5 × (n − 1) × 0.20

  The 1.5 exponent gives a steep curve at the low-avg end (the canonical case to punish) while keeping healthy 2-for-1s mild. 1-for-1 returns 0 (n-1 = 0); avg ≥ target returns 0.

* **suggest_evening_piece(adjustment)** helper that maps an adjustment amount back to a human-readable piece description ("≈ a 2026 Mid 1st", "≈ a fringe WR1") so the KTC reverse-engineering intuition surfaces in a paste-able form.

* **ValueAdjustment dataclass** now exposes per-component fields (spot_component, tier_premium, isolation_gap, dilution) so callers can render or assert on each piece individually.

Verification:

* Egbuka + Kyler → Bijan: adjustment goes from +6,395 (v1) to +8,006 (v2), with the new isolation_gap (+2,449) and dilution (+686) components surfaced separately. Adjusted delta lands at −8,197 vs −6,586 — significantly more "you're underpaying."

* 10×1000 KTC for 10000 KTC stud (the docs example): total adjustment exceeds 20K KTC. Adjusted delta is deeply negative — the trade is correctly flagged as unfair.

* Fannin + discounted Mayfield → JSN: still lands in the "needs ~1st + a piece" range the user's intuition expects.

Tests: 94 pass (was 80). 14 new tests across dilution behavior, isolation-counts-all-chips, the docs' canonical 10-for-1 case, and the suggest_evening_piece label mapping.