### PR TITLE
fix(cli): inbox/outbox/waivers crashed — async SleeperClient used as a sync context manager

### DIFF
--- a/python/src/sleeper/cli_agent.py
+++ b/python/src/sleeper/cli_agent.py
@@ -232,8 +232,15 @@ def cmd_inbox(args) -> None:
         my_rid = _resolve_my_roster_id(ctx)
         ktc = _ktc_lookup_for_context(ctx, args.format)
 
-        with SleeperClient() as c:
-            sleeper_players = c.sync(c.get_all_players())
+        c = SleeperClient()
+
+        async def _fetch_players():
+            try:
+                return await c.get_all_players()
+            finally:
+                await c.close()
+
+        sleeper_players = c.sync(_fetch_players())
 
         with SleeperAuthClient() as auth:
             trades = auth.get_inbox(ctx["league"]["league_id"], my_roster_id=my_rid)
@@ -251,8 +258,15 @@ def cmd_outbox(args) -> None:
         ctx = build_context(args.username, args.league)
         my_rid = _resolve_my_roster_id(ctx)
         ktc = _ktc_lookup_for_context(ctx, args.format)
-        with SleeperClient() as c:
-            sleeper_players = c.sync(c.get_all_players())
+        c = SleeperClient()
+
+        async def _fetch_players():
+            try:
+                return await c.get_all_players()
+            finally:
+                await c.close()
+
+        sleeper_players = c.sync(_fetch_players())
         with SleeperAuthClient() as auth:
             trades = auth.get_outbox(ctx["league"]["league_id"], my_roster_id=my_rid)
         rows = summarize_inbox(trades, my_roster_id=my_rid,
@@ -284,9 +298,17 @@ def cmd_waivers(args) -> None:
         from sleeper.client import SleeperClient
         ctx = build_context(args.username, args.league)
         # Build FA pool: all players minus everyone rostered.
-        with SleeperClient() as c:
-            sleeper_players = c.sync(c.get_all_players())
-            rosters = c.sync(c.leagues.get_rosters(ctx["league"]["league_id"]))
+        c = SleeperClient()
+
+        async def _fetch_pool():
+            try:
+                players = await c.get_all_players()
+                rosters = await c.leagues.get_rosters(ctx["league"]["league_id"])
+                return players, rosters
+            finally:
+                await c.close()
+
+        sleeper_players, rosters = c.sync(_fetch_pool())
         rostered = set()
         for r in rosters:
             for pid in (r.players or []):


### PR DESCRIPTION
## Problem

Two stacked bugs in `cli_agent.py` broke `inbox`, `outbox`, and `waivers`:

**1. Sync `with` on an async-only client.** `SleeperClient` implements `__aenter__`/`__aexit__` only, but these three commands wrapped it in a synchronous `with SleeperClient() as c:`, so all three crashed immediately:

```
sleeper waivers <user> --league "<name>"
→ ❌ [INTERNAL] __enter__
```

**2. One event loop per call.** After fixing the context manager, a naive `c.sync(...)` per call still fails multi-fetch commands: each `SleeperClient.sync()` spins a fresh `asyncio.run` loop while the shared httpx `AsyncClient` stays bound to the first (now closed) loop, so the second fetch dies with `RuntimeError: Event loop is closed`.

## Fix

Run each command's fetches as **one** coroutine through `SleeperClient.sync()` — the same convention `agent/helpers.py` documents ("Every helper is sync-callable via SleeperClient.sync") — and close the client inside the coroutine.

## Verification

- `sleeper waivers <user> --league "<name>" --top 5` now returns ranked free agents (live, with KTC values).
- `inbox` / `outbox` now reach the expected `SLEEPER_TOKEN` check instead of crashing.
- Full suite: 186 passed.