### PR TITLE
fix: DraftPick.roster_id is an int; flag injuries on the draft board

### DIFF
--- a/.claude/commands/draft-assist.md
+++ b/.claude/commands/draft-assist.md
@@ -24,6 +24,7 @@ python3 scripts/draft_assist.py USERNAME --league NAME --once
 - Values come from `data/ktc/latest.json` (the committed daily snapshot) — no scrape, no token
 - Announces each new pick with its KTC value and pre-draft board rank; flags the user's own picks
 - Reprints best available: top N overall, plus top 5 per position with `|CLIFF` markers on value drops ≥400
+- Flags injuries from Sleeper's player data: `[IR]` `[OUT]` `[PUP]` `[DOUBT]` `[SUSP]` are loud (the player cannot help you now); `[q]` is quiet, because Questionable is a Week 1 blanket designation that most of the pool carries
 - Shows who's on the clock and how many picks until the user's turn (snake-aware)
 - Tracks the user's roster as it builds
 
@@ -32,6 +33,7 @@ python3 scripts/draft_assist.py USERNAME --league NAME --once
 - Read-only — it cannot make picks; draft in the Sleeper app
 - KTC is a **dynasty** market; in redraft leagues treat values as a market signal, not a ranking
 - K and DEF have no KTC values and never appear on the board
+- The board ranks on KTC value alone. It knows about **injuries** but not **depth-chart role** — a backup and a starter at the same value look identical, so verify snap share before recommending a late-round flier
 - If the user has no draft slot assigned yet, "your turn in N picks" is unavailable until Sleeper assigns slots
 
 ## When invoked as a skill

--- a/python/scripts/draft_assist.py
+++ b/python/scripts/draft_assist.py
@@ -31,6 +31,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 KTC_LATEST = REPO_ROOT / "data" / "ktc" / "latest.json"
 VALUED_POSITIONS = ("QB", "RB", "WR", "TE")
 
+# Loud tags mean the player cannot help you now; "Questionable" is a Week 1
+# blanket designation (most of the pool carries it) so it stays quiet.
+INJURY_TAGS = {
+    "IR": " [IR]", "Out": " [OUT]", "Doubtful": " [DOUBT]",
+    "PUP": " [PUP]", "Sus": " [SUSP]", "NA": " [NA]",
+    "Questionable": " [q]",
+}
+
 
 def norm(name: str) -> str:
     name = name.lower()
@@ -52,6 +60,32 @@ def load_board(value_key: str) -> dict[tuple[str, str], dict]:
     return board
 
 
+async def build_injury_map(client) -> dict[str, str]:
+    """norm_name -> short injury tag, from Sleeper's player database.
+
+    The KTC board prices a player on dynasty market value alone, so an IR
+    player renders identically to a healthy one. Joining Sleeper's injury
+    field is the only thing that stops the board recommending someone who
+    is not going to play.
+    """
+    try:
+        players = await client.get_all_players()
+    except Exception:
+        return {}
+    out = {}
+    for p in players.values():
+        status = getattr(p, "injury_status", None)
+        inactive = getattr(p, "status", None) in ("Inactive", "Injured Reserve")
+        if not status and not inactive:
+            continue
+        tag = INJURY_TAGS.get(status or "", " [OUT]" if inactive else "")
+        if status == "Questionable" and inactive:
+            tag = " [IR]"
+        if tag and p.full_name:
+            out[norm(p.full_name)] = tag
+    return out
+
+
 def snake_slot(pick_no: int, teams: int) -> int:
     idx = (pick_no - 1) % teams
     rnd = (pick_no - 1) // teams + 1
@@ -66,7 +100,7 @@ def fmt_pick_no(pick_no: int, teams: int) -> str:
 def print_board(available: list[dict], top: int) -> None:
     print(f"\n  BEST AVAILABLE (top {top} overall)")
     for i, p in enumerate(available[:top], 1):
-        print(f"   {i:>2}. {p['name']:<24} {p['position']:<3} {p['team'] or 'FA':<4} {p['value']:>5}")
+        print(f"   {i:>2}. {p['name']:<24} {p['position']:<3} {p['team'] or 'FA':<4} {p['value']:>5}{p.get('inj', '')}")
     for pos in VALUED_POSITIONS:
         pool = [p for p in available if p["position"] == pos][:5]
         if not pool:
@@ -75,7 +109,7 @@ def print_board(available: list[dict], top: int) -> None:
         for j, p in enumerate(pool):
             gap = pool[j - 1]["value"] - p["value"] if j else 0
             cliff = " |CLIFF" if j and gap >= 400 else ""
-            parts.append(f"{p['name']} {p['value']}{cliff}")
+            parts.append(f"{p['name']} {p['value']}{p.get('inj', '')}{cliff}")
         print(f"   {pos:<3}: " + "  ·  ".join(parts))
 
 
@@ -110,6 +144,9 @@ async def run(args: argparse.Namespace) -> None:
 
         board = load_board(value_key)
         board_by_key = dict(board)  # (norm_name, pos) -> rec
+        injuries = await build_injury_map(client)
+        for _k, _rec in board_by_key.items():
+            _rec["inj"] = injuries.get(norm(_rec["name"]), "")
         print(f"Draft co-pilot — {league.name if league else draft_id} | {teams} teams | "
               f"{'SF' if superflex else '1QB'} values | your slot: {my_slot or '?'}")
         print(f"KTC snapshot: {json.loads(KTC_LATEST.read_text())['date']} "

--- a/python/src/sleeper/analytics/dynasty.py
+++ b/python/src/sleeper/analytics/dynasty.py
@@ -14,7 +14,7 @@ class DraftMapEntry:
     pick_no: int
     round: int
     draft_slot: Optional[int] = None
-    roster_id: Optional[str] = None
+    roster_id: Optional[int] = None  # roster_id (int), mirrors DraftPick.roster_id
     picked_by: Optional[str] = None
     first_name: Optional[str] = None
     last_name: Optional[str] = None

--- a/python/src/sleeper/types/draft.py
+++ b/python/src/sleeper/types/draft.py
@@ -34,7 +34,7 @@ class DraftPick(BaseModel):
     draft_id: str
     player_id: str | None = None
     picked_by: str | None = None
-    roster_id: str | None = None
+    roster_id: int | None = None  # roster_id (int), matches Roster.roster_id
     round: int
     draft_slot: int | None = None
     pick_no: int


### PR DESCRIPTION
Two fixes found while running `scripts/draft_assist.py` for a real draft

## 1. `DraftPick.roster_id` was the wrong type (causes crash)

Sleeper's `/draft/<id>/picks` returns `roster_id` as a JSON number, but the model typed it `str`. Pydantic rejected every real payload, so `get_picks()` raised `ValidationError` and the co-pilot **could not run at all** against a live draft:

Every other roster-bearing model in the package: `Roster`, `Matchup`, `Transaction`, `TradedPick` — already types `roster_id` as an `int`, so `DraftPick` was the lone outlier. `DraftMapEntry.roster_id` in `analytics/dynasty.py` mirrored the wrong type and is corrected alongside it; mypy caught that second one.

## 2. The board ranked on KTC value alone, ignoring injuries

A player on IR rendered identically to a healthy one at the top of `BEST AVAILABLE`. This isn't cosmetic — during a live draft the board surfaced a receiver as the top available player for three consecutive checks while he was on IR with a two-month timeline, because nothing in the output could distinguish him.

The board now joins Sleeper's injury field:

```
RB : Mike Washington Jr. 3963 · Zach Charbonnet 3952 [PUP] · Croskey-Merritt 3930 [q]
WR : Denzel Boston 4600 · Matthew Golden 4596 · Jayden Higgins 3795 [IR]
```

`[IR] [OUT] [PUP] [DOUBT] [SUSP]` are loud — the player cannot help you now. `Questionable` renders as a quiet `[q]`, because it's a Week 1 blanket designation that most of the pool carries; treating it as loud would flag everyone and inform nobody. The join degrades gracefully: if the player fetch fails, the board renders exactly as before.