### PR TITLE
Fix agent CLI: inspect_token, Roster.taxi, sync client, lineup mutation

### DIFF
--- a/python/src/sleeper/auth/__init__.py
+++ b/python/src/sleeper/auth/__init__.py
@@ -13,6 +13,6 @@ Usage:
     client = SleeperAuthClient()
     pending = client.get_trades(league_id, statuses=["pending"])
 """
-from sleeper.auth.client import SleeperAuthClient, SleeperAuthError
+from sleeper.auth.client import SleeperAuthClient, SleeperAuthError, inspect_token
 
-__all__ = ["SleeperAuthClient", "SleeperAuthError"]
+__all__ = ["SleeperAuthClient", "SleeperAuthError", "inspect_token"]

--- a/python/src/sleeper/auth/client.py
+++ b/python/src/sleeper/auth/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import time
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -60,6 +61,25 @@ def _normalize_errors(errs) -> list:
     if isinstance(errs, list):
         return [e if isinstance(e, dict) else {"message": str(e)} for e in errs]
     return [{"message": str(errs)}]
+
+
+def _snowflake(value: str | int) -> str:
+    """Reject anything that is not a numeric Sleeper id before interpolating GraphQL."""
+    s = str(value)
+    if not re.fullmatch(r"[0-9]+", s):
+        raise ValueError(f"invalid sleeper id: {value!r}")
+    return s
+
+
+def _player_ids(ids: list[str]) -> list[str]:
+    """Reject player ids that are not alphanumeric (digits or DEF codes like DEN)."""
+    out: list[str] = []
+    for pid in ids:
+        s = str(pid)
+        if not re.fullmatch(r"[A-Za-z0-9]+", s):
+            raise ValueError(f"invalid player_id: {pid!r}")
+        out.append(s)
+    return out
 
 
 def inspect_token(jwt: str) -> TokenInfo:
@@ -372,27 +392,42 @@ class SleeperAuthClient:
         starters: list[str],
         *,
         leg: int | None = None,
+        round: int | None = None,
     ) -> dict:
-        """Set the starters list for a roster. Order must match league
-        roster_positions slots (excluding BN/IR/TAXI)."""
-        query = """
-        mutation update_roster_starters(
-          $league_id: Snowflake!, $roster_id: Int!, $starters: [String]!, $leg: Int
-        ) {
-          update_roster_starters(
-            league_id: $league_id, roster_id: $roster_id, starters: $starters, leg: $leg
-          ) {
-            roster_id starters players reserve taxi
-          }
-        }
+        """Set the weekly lineup via ``update_matchup_leg``.
+
+        In-season Sleeper no longer exposes ``update_roster_starters``. The web
+        client inlines ``league_id`` / ``roster_id`` / ``leg`` / ``round`` /
+        ``starters`` and only uses a variable for ``starters_games``. ``leg`` and
+        ``round`` are the current NFL week for regular-season matchups.
         """
-        data = self.gql("update_roster_starters", query, {
-            "league_id": league_id,
-            "roster_id": roster_id,
-            "starters": starters,
-            "leg": leg,
-        })
-        return data.get("update_roster_starters") or {}
+        week = int(round if round is not None else (leg if leg is not None else 1))
+        matchup_leg = int(leg if leg is not None else week)
+        safe_league = _snowflake(league_id)
+        safe_roster = int(roster_id)
+        safe_starters = json.dumps(_player_ids(starters))
+        query = f"""
+        mutation update_matchup_leg($starters_games: Map) {{
+          update_matchup_leg(
+            league_id: "{safe_league}",
+            roster_id: {safe_roster},
+            leg: {matchup_leg},
+            round: {week},
+            starters: {safe_starters},
+            starters_games: $starters_games
+          ) {{
+            league_id
+            leg
+            matchup_id
+            roster_id
+            round
+            starters
+            players
+          }}
+        }}
+        """
+        data = self.gql("update_matchup_leg", query, {})
+        return data.get("update_matchup_leg") or {}
 
     def add_drop(
         self,

--- a/python/src/sleeper/cli_agent.py
+++ b/python/src/sleeper/cli_agent.py
@@ -404,12 +404,19 @@ def cmd_lineup_set(args) -> None:
         league_id = ctx["league"]["league_id"]
         roster_id = _resolve_my_roster_id(ctx)
         starters = [s.strip() for s in (args.starters or "").split(",") if s.strip()]
-        payload = {"league_id": league_id, "roster_id": roster_id, "starters": starters}
-        summary = f"Set {len(starters)} starters in {ctx['league']['name']} week {ctx.get('week')}"
+        week = int(ctx.get("week") or 1)
+        payload = {
+            "league_id": league_id,
+            "roster_id": roster_id,
+            "starters": starters,
+            "leg": week,
+            "round": week,
+        }
+        summary = f"Set {len(starters)} starters in {ctx['league']['name']} week {week}"
 
         def _do_write():
             with SleeperAuthClient() as auth:
-                return auth.set_starters(league_id, roster_id, starters)
+                return auth.set_starters(league_id, roster_id, starters, leg=week, round=week)
 
         return _exec_or_preview(args, command="lineup-set", payload=payload,
                                 summary=summary, executor=_do_write)
@@ -548,7 +555,13 @@ def cmd_execute(args) -> None:
                     return auth.accept_trade(p["league_id"], p["transaction_id"], p["leg"])
                 return auth.reject_trade(p["league_id"], p["transaction_id"], p["leg"])
             if cmd == "lineup-set":
-                return auth.set_starters(p["league_id"], p["roster_id"], p["starters"])
+                return auth.set_starters(
+                    p["league_id"],
+                    p["roster_id"],
+                    p["starters"],
+                    leg=p.get("leg"),
+                    round=p.get("round"),
+                )
             if cmd == "waiver-claim":
                 return auth.submit_waiver_claim(
                     p["league_id"], p["roster_id"],

--- a/python/src/sleeper/cli_agent.py
+++ b/python/src/sleeper/cli_agent.py
@@ -232,8 +232,8 @@ def cmd_inbox(args) -> None:
         my_rid = _resolve_my_roster_id(ctx)
         ktc = _ktc_lookup_for_context(ctx, args.format)
 
-        with SleeperClient() as c:
-            sleeper_players = c.sync(c.get_all_players())
+        c = SleeperClient()
+        sleeper_players = c.sync(c.get_all_players())
 
         with SleeperAuthClient() as auth:
             trades = auth.get_inbox(ctx["league"]["league_id"], my_roster_id=my_rid)
@@ -251,8 +251,8 @@ def cmd_outbox(args) -> None:
         ctx = build_context(args.username, args.league)
         my_rid = _resolve_my_roster_id(ctx)
         ktc = _ktc_lookup_for_context(ctx, args.format)
-        with SleeperClient() as c:
-            sleeper_players = c.sync(c.get_all_players())
+        c = SleeperClient()
+        sleeper_players = c.sync(c.get_all_players())
         with SleeperAuthClient() as auth:
             trades = auth.get_outbox(ctx["league"]["league_id"], my_roster_id=my_rid)
         rows = summarize_inbox(trades, my_roster_id=my_rid,
@@ -284,9 +284,11 @@ def cmd_waivers(args) -> None:
         from sleeper.client import SleeperClient
         ctx = build_context(args.username, args.league)
         # Build FA pool: all players minus everyone rostered.
-        with SleeperClient() as c:
-            sleeper_players = c.sync(c.get_all_players())
-            rosters = c.sync(c.leagues.get_rosters(ctx["league"]["league_id"]))
+        # SleeperClient only implements the async context manager protocol
+        # (__aenter__/__aexit__) — use the documented sync-shortcut pattern.
+        c = SleeperClient()
+        sleeper_players = c.sync(c.get_all_players())
+        rosters = c.sync(c.leagues.get_rosters(ctx["league"]["league_id"]))
         rostered = set()
         for r in rosters:
             for pid in (r.players or []):

--- a/python/src/sleeper/types/league.py
+++ b/python/src/sleeper/types/league.py
@@ -23,6 +23,7 @@ class Roster(BaseModel):
     starters: list[str] = []
     players: list[str] = []
     reserve: list[str] | None = None
+    taxi: list[str] | None = None
     settings: RosterSettings | None = None
 
     @property


### PR DESCRIPTION
Found these while wrapping the agent CLI as MCP tools for an AI agent — all break on a fresh install / real league.

## 1. `auth-check` crashes on import

`cli_agent.py` does `from sleeper.auth import ... inspect_token`, but `sleeper/auth/__init__.py` only exports `SleeperAuthClient` and `SleeperAuthError`. `inspect_token` is defined in `sleeper/auth/client.py` but never re-exported.

Fix: re-export it from `sleeper/auth/__init__.py`.

## 2. Almost every read command crashes on any roster

`build_context` accesses `r.taxi`, but the `Roster` Pydantic model was missing `taxi`. Sleeper's payload includes it, so Pydantic dropped it and anything touching a roster threw `AttributeError`.

Fix: add `taxi: list[str] | None = None` to `Roster`.

## 3. `waivers` / `inbox` / `outbox` used a sync context manager

`SleeperClient` only implements `__aenter__` / `__aexit__`. Those commands used `with SleeperClient()`.

Fix: instantiate the client and use `.sync()` as the README documents.

## 4. `lineup-set` calls a mutation that no longer exists

`set_starters()` posted `update_roster_starters`, which Sleeper's current GraphQL schema rejects (`Cannot query field "update_roster_starters" on type "RootMutationType"`). The live web client now uses `update_matchup_leg` with inlined `league_id` / `roster_id` / `leg` / `round` / `starters`.

Fix: rewrite `set_starters` to match that payload, and pass the current week through `lineup-set` / `execute`.

## Testing

Verified 1–3 against a real league. Verified 4 by executing a live week-1 starter swap (`update_matchup_leg` returned the new `starters` list). No existing tests touch these paths.