### PR TITLE
fix: agent CLI roster reads and lineup write mutation

### DIFF
--- a/.claude/commands/draft-assist.md
+++ b/.claude/commands/draft-assist.md
@@ -24,6 +24,7 @@ python3 scripts/draft_assist.py USERNAME --league NAME --once
 - Values come from `data/ktc/latest.json` (the committed daily snapshot) — no scrape, no token
 - Announces each new pick with its KTC value and pre-draft board rank; flags the user's own picks
 - Reprints best available: top N overall, plus top 5 per position with `|CLIFF` markers on value drops ≥400
+- Flags injuries from Sleeper's player data: `[IR]` `[OUT]` `[PUP]` `[DOUBT]` `[SUSP]` are loud (the player cannot help you now); `[q]` is quiet, because Questionable is a Week 1 blanket designation that most of the pool carries
 - Shows who's on the clock and how many picks until the user's turn (snake-aware)
 - Tracks the user's roster as it builds
 
@@ -32,6 +33,7 @@ python3 scripts/draft_assist.py USERNAME --league NAME --once
 - Read-only — it cannot make picks; draft in the Sleeper app
 - KTC is a **dynasty** market; in redraft leagues treat values as a market signal, not a ranking
 - K and DEF have no KTC values and never appear on the board
+- The board ranks on KTC value alone. It knows about **injuries** but not **depth-chart role** — a backup and a starter at the same value look identical, so verify snap share before recommending a late-round flier
 - If the user has no draft slot assigned yet, "your turn in N picks" is unavailable until Sleeper assigns slots
 
 ## When invoked as a skill

--- a/python/scripts/draft_assist.py
+++ b/python/scripts/draft_assist.py
@@ -31,6 +31,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 KTC_LATEST = REPO_ROOT / "data" / "ktc" / "latest.json"
 VALUED_POSITIONS = ("QB", "RB", "WR", "TE")
 
+# Loud tags mean the player cannot help you now; "Questionable" is a Week 1
+# blanket designation (most of the pool carries it) so it stays quiet.
+INJURY_TAGS = {
+    "IR": " [IR]", "Out": " [OUT]", "Doubtful": " [DOUBT]",
+    "PUP": " [PUP]", "Sus": " [SUSP]", "NA": " [NA]",
+    "Questionable": " [q]",
+}
+
 
 def norm(name: str) -> str:
     name = name.lower()
@@ -52,6 +60,32 @@ def load_board(value_key: str) -> dict[tuple[str, str], dict]:
     return board
 
 
+async def build_injury_map(client) -> dict[str, str]:
+    """norm_name -> short injury tag, from Sleeper's player database.
+
+    The KTC board prices a player on dynasty market value alone, so an IR
+    player renders identically to a healthy one. Joining Sleeper's injury
+    field is the only thing that stops the board recommending someone who
+    is not going to play.
+    """
+    try:
+        players = await client.get_all_players()
+    except Exception:
+        return {}
+    out = {}
+    for p in players.values():
+        status = getattr(p, "injury_status", None)
+        inactive = getattr(p, "status", None) in ("Inactive", "Injured Reserve")
+        if not status and not inactive:
+            continue
+        tag = INJURY_TAGS.get(status or "", " [OUT]" if inactive else "")
+        if status == "Questionable" and inactive:
+            tag = " [IR]"
+        if tag and p.full_name:
+            out[norm(p.full_name)] = tag
+    return out
+
+
 def snake_slot(pick_no: int, teams: int) -> int:
     idx = (pick_no - 1) % teams
     rnd = (pick_no - 1) // teams + 1
@@ -66,7 +100,7 @@ def fmt_pick_no(pick_no: int, teams: int) -> str:
 def print_board(available: list[dict], top: int) -> None:
     print(f"\n  BEST AVAILABLE (top {top} overall)")
     for i, p in enumerate(available[:top], 1):
-        print(f"   {i:>2}. {p['name']:<24} {p['position']:<3} {p['team'] or 'FA':<4} {p['value']:>5}")
+        print(f"   {i:>2}. {p['name']:<24} {p['position']:<3} {p['team'] or 'FA':<4} {p['value']:>5}{p.get('inj', '')}")
     for pos in VALUED_POSITIONS:
         pool = [p for p in available if p["position"] == pos][:5]
         if not pool:
@@ -75,7 +109,7 @@ def print_board(available: list[dict], top: int) -> None:
         for j, p in enumerate(pool):
             gap = pool[j - 1]["value"] - p["value"] if j else 0
             cliff = " |CLIFF" if j and gap >= 400 else ""
-            parts.append(f"{p['name']} {p['value']}{cliff}")
+            parts.append(f"{p['name']} {p['value']}{p.get('inj', '')}{cliff}")
         print(f"   {pos:<3}: " + "  ·  ".join(parts))
 
 
@@ -110,6 +144,9 @@ async def run(args: argparse.Namespace) -> None:
 
         board = load_board(value_key)
         board_by_key = dict(board)  # (norm_name, pos) -> rec
+        injuries = await build_injury_map(client)
+        for _k, _rec in board_by_key.items():
+            _rec["inj"] = injuries.get(norm(_rec["name"]), "")
         print(f"Draft co-pilot — {league.name if league else draft_id} | {teams} teams | "
               f"{'SF' if superflex else '1QB'} values | your slot: {my_slot or '?'}")
         print(f"KTC snapshot: {json.loads(KTC_LATEST.read_text())['date']} "

--- a/python/src/sleeper/analytics/dynasty.py
+++ b/python/src/sleeper/analytics/dynasty.py
@@ -14,7 +14,7 @@ class DraftMapEntry:
     pick_no: int
     round: int
     draft_slot: Optional[int] = None
-    roster_id: Optional[str] = None
+    roster_id: Optional[int] = None  # roster_id (int), mirrors DraftPick.roster_id
     picked_by: Optional[str] = None
     first_name: Optional[str] = None
     last_name: Optional[str] = None

--- a/python/src/sleeper/auth/__init__.py
+++ b/python/src/sleeper/auth/__init__.py
@@ -13,6 +13,6 @@ Usage:
     client = SleeperAuthClient()
     pending = client.get_trades(league_id, statuses=["pending"])
 """
-from sleeper.auth.client import SleeperAuthClient, SleeperAuthError
+from sleeper.auth.client import SleeperAuthClient, SleeperAuthError, inspect_token
 
-__all__ = ["SleeperAuthClient", "SleeperAuthError"]
+__all__ = ["SleeperAuthClient", "SleeperAuthError", "inspect_token"]

--- a/python/src/sleeper/auth/client.py
+++ b/python/src/sleeper/auth/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import time
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -60,6 +61,25 @@ def _normalize_errors(errs) -> list:
     if isinstance(errs, list):
         return [e if isinstance(e, dict) else {"message": str(e)} for e in errs]
     return [{"message": str(errs)}]
+
+
+def _snowflake(value: str | int) -> str:
+    """Reject anything that is not a numeric Sleeper id before interpolating GraphQL."""
+    s = str(value)
+    if not re.fullmatch(r"[0-9]+", s):
+        raise ValueError(f"invalid sleeper id: {value!r}")
+    return s
+
+
+def _player_ids(ids: list[str]) -> list[str]:
+    """Reject player ids that are not alphanumeric (digits or DEF codes like DEN)."""
+    out: list[str] = []
+    for pid in ids:
+        s = str(pid)
+        if not re.fullmatch(r"[A-Za-z0-9]+", s):
+            raise ValueError(f"invalid player_id: {pid!r}")
+        out.append(s)
+    return out
 
 
 def inspect_token(jwt: str) -> TokenInfo:
@@ -372,27 +392,42 @@ class SleeperAuthClient:
         starters: list[str],
         *,
         leg: int | None = None,
+        round: int | None = None,
     ) -> dict:
-        """Set the starters list for a roster. Order must match league
-        roster_positions slots (excluding BN/IR/TAXI)."""
-        query = """
-        mutation update_roster_starters(
-          $league_id: Snowflake!, $roster_id: Int!, $starters: [String]!, $leg: Int
-        ) {
-          update_roster_starters(
-            league_id: $league_id, roster_id: $roster_id, starters: $starters, leg: $leg
-          ) {
-            roster_id starters players reserve taxi
-          }
-        }
+        """Set the weekly lineup via ``update_matchup_leg``.
+
+        In-season Sleeper no longer exposes ``update_roster_starters``. The web
+        client inlines ``league_id`` / ``roster_id`` / ``leg`` / ``round`` /
+        ``starters`` and only uses a variable for ``starters_games``. ``leg`` and
+        ``round`` are the current NFL week for regular-season matchups.
         """
-        data = self.gql("update_roster_starters", query, {
-            "league_id": league_id,
-            "roster_id": roster_id,
-            "starters": starters,
-            "leg": leg,
-        })
-        return data.get("update_roster_starters") or {}
+        week = int(round if round is not None else (leg if leg is not None else 1))
+        matchup_leg = int(leg if leg is not None else week)
+        safe_league = _snowflake(league_id)
+        safe_roster = int(roster_id)
+        safe_starters = json.dumps(_player_ids(starters))
+        query = f"""
+        mutation update_matchup_leg($starters_games: Map) {{
+          update_matchup_leg(
+            league_id: "{safe_league}",
+            roster_id: {safe_roster},
+            leg: {matchup_leg},
+            round: {week},
+            starters: {safe_starters},
+            starters_games: $starters_games
+          ) {{
+            league_id
+            leg
+            matchup_id
+            roster_id
+            round
+            starters
+            players
+          }}
+        }}
+        """
+        data = self.gql("update_matchup_leg", query, {})
+        return data.get("update_matchup_leg") or {}
 
     def add_drop(
         self,

--- a/python/src/sleeper/cli_agent.py
+++ b/python/src/sleeper/cli_agent.py
@@ -233,7 +233,14 @@ def cmd_inbox(args) -> None:
         ktc = _ktc_lookup_for_context(ctx, args.format)
 
         c = SleeperClient()
-        sleeper_players = c.sync(c.get_all_players())
+
+        async def _fetch_players():
+            try:
+                return await c.get_all_players()
+            finally:
+                await c.close()
+
+        sleeper_players = c.sync(_fetch_players())
 
         with SleeperAuthClient() as auth:
             trades = auth.get_inbox(ctx["league"]["league_id"], my_roster_id=my_rid)
@@ -252,7 +259,14 @@ def cmd_outbox(args) -> None:
         my_rid = _resolve_my_roster_id(ctx)
         ktc = _ktc_lookup_for_context(ctx, args.format)
         c = SleeperClient()
-        sleeper_players = c.sync(c.get_all_players())
+
+        async def _fetch_players():
+            try:
+                return await c.get_all_players()
+            finally:
+                await c.close()
+
+        sleeper_players = c.sync(_fetch_players())
         with SleeperAuthClient() as auth:
             trades = auth.get_outbox(ctx["league"]["league_id"], my_roster_id=my_rid)
         rows = summarize_inbox(trades, my_roster_id=my_rid,
@@ -284,11 +298,17 @@ def cmd_waivers(args) -> None:
         from sleeper.client import SleeperClient
         ctx = build_context(args.username, args.league)
         # Build FA pool: all players minus everyone rostered.
-        # SleeperClient only implements the async context manager protocol
-        # (__aenter__/__aexit__) — use the documented sync-shortcut pattern.
         c = SleeperClient()
-        sleeper_players = c.sync(c.get_all_players())
-        rosters = c.sync(c.leagues.get_rosters(ctx["league"]["league_id"]))
+
+        async def _fetch_pool():
+            try:
+                players = await c.get_all_players()
+                rosters = await c.leagues.get_rosters(ctx["league"]["league_id"])
+                return players, rosters
+            finally:
+                await c.close()
+
+        sleeper_players, rosters = c.sync(_fetch_pool())
         rostered = set()
         for r in rosters:
             for pid in (r.players or []):

--- a/python/src/sleeper/cli_agent.py
+++ b/python/src/sleeper/cli_agent.py
@@ -404,12 +404,19 @@ def cmd_lineup_set(args) -> None:
         league_id = ctx["league"]["league_id"]
         roster_id = _resolve_my_roster_id(ctx)
         starters = [s.strip() for s in (args.starters or "").split(",") if s.strip()]
-        payload = {"league_id": league_id, "roster_id": roster_id, "starters": starters}
-        summary = f"Set {len(starters)} starters in {ctx['league']['name']} week {ctx.get('week')}"
+        week = int(ctx.get("week") or 1)
+        payload = {
+            "league_id": league_id,
+            "roster_id": roster_id,
+            "starters": starters,
+            "leg": week,
+            "round": week,
+        }
+        summary = f"Set {len(starters)} starters in {ctx['league']['name']} week {week}"
 
         def _do_write():
             with SleeperAuthClient() as auth:
-                return auth.set_starters(league_id, roster_id, starters)
+                return auth.set_starters(league_id, roster_id, starters, leg=week, round=week)
 
         return _exec_or_preview(args, command="lineup-set", payload=payload,
                                 summary=summary, executor=_do_write)
@@ -548,7 +555,13 @@ def cmd_execute(args) -> None:
                     return auth.accept_trade(p["league_id"], p["transaction_id"], p["leg"])
                 return auth.reject_trade(p["league_id"], p["transaction_id"], p["leg"])
             if cmd == "lineup-set":
-                return auth.set_starters(p["league_id"], p["roster_id"], p["starters"])
+                return auth.set_starters(
+                    p["league_id"],
+                    p["roster_id"],
+                    p["starters"],
+                    leg=p.get("leg"),
+                    round=p.get("round"),
+                )
             if cmd == "waiver-claim":
                 return auth.submit_waiver_claim(
                     p["league_id"], p["roster_id"],

--- a/python/src/sleeper/cli_agent.py
+++ b/python/src/sleeper/cli_agent.py
@@ -232,8 +232,8 @@ def cmd_inbox(args) -> None:
         my_rid = _resolve_my_roster_id(ctx)
         ktc = _ktc_lookup_for_context(ctx, args.format)
 
-        with SleeperClient() as c:
-            sleeper_players = c.sync(c.get_all_players())
+        c = SleeperClient()
+        sleeper_players = c.sync(c.get_all_players())
 
         with SleeperAuthClient() as auth:
             trades = auth.get_inbox(ctx["league"]["league_id"], my_roster_id=my_rid)
@@ -251,8 +251,8 @@ def cmd_outbox(args) -> None:
         ctx = build_context(args.username, args.league)
         my_rid = _resolve_my_roster_id(ctx)
         ktc = _ktc_lookup_for_context(ctx, args.format)
-        with SleeperClient() as c:
-            sleeper_players = c.sync(c.get_all_players())
+        c = SleeperClient()
+        sleeper_players = c.sync(c.get_all_players())
         with SleeperAuthClient() as auth:
             trades = auth.get_outbox(ctx["league"]["league_id"], my_roster_id=my_rid)
         rows = summarize_inbox(trades, my_roster_id=my_rid,
@@ -284,9 +284,11 @@ def cmd_waivers(args) -> None:
         from sleeper.client import SleeperClient
         ctx = build_context(args.username, args.league)
         # Build FA pool: all players minus everyone rostered.
-        with SleeperClient() as c:
-            sleeper_players = c.sync(c.get_all_players())
-            rosters = c.sync(c.leagues.get_rosters(ctx["league"]["league_id"]))
+        # SleeperClient only implements the async context manager protocol
+        # (__aenter__/__aexit__) — use the documented sync-shortcut pattern.
+        c = SleeperClient()
+        sleeper_players = c.sync(c.get_all_players())
+        rosters = c.sync(c.leagues.get_rosters(ctx["league"]["league_id"]))
         rostered = set()
         for r in rosters:
             for pid in (r.players or []):

--- a/python/src/sleeper/types/draft.py
+++ b/python/src/sleeper/types/draft.py
@@ -34,7 +34,7 @@ class DraftPick(BaseModel):
     draft_id: str
     player_id: str | None = None
     picked_by: str | None = None
-    roster_id: str | None = None
+    roster_id: int | None = None  # roster_id (int), matches Roster.roster_id
     round: int
     draft_slot: int | None = None
     pick_no: int

--- a/python/src/sleeper/types/league.py
+++ b/python/src/sleeper/types/league.py
@@ -24,6 +24,9 @@ class Roster(BaseModel):
     players: list[str] = []
     reserve: list[str] | None = None
     taxi: list[str] | None = None
+    co_owners: list[str] | None = None
+    keepers: list[str] | None = None
+    metadata: dict[str, Any] | None = None
     settings: RosterSettings | None = None
 
     @property

--- a/python/src/sleeper/types/league.py
+++ b/python/src/sleeper/types/league.py
@@ -23,6 +23,7 @@ class Roster(BaseModel):
     starters: list[str] = []
     players: list[str] = []
     reserve: list[str] | None = None
+    taxi: list[str] | None = None
     settings: RosterSettings | None = None
 
     @property

--- a/python/tests/test_roster_model.py
+++ b/python/tests/test_roster_model.py
@@ -1,0 +1,67 @@
+"""Regression tests for the Roster model against Sleeper's real payload shape.
+
+The Roster model previously omitted ``taxi``, ``co_owners``, ``keepers``, and
+``metadata``, so pydantic silently dropped them at validation time. Agent code
+reading ``roster.taxi`` (``agent/helpers.build_context``) then crashed with
+``AttributeError: 'Roster' object has no attribute 'taxi'``, breaking every
+command that builds roster context: ``context``, ``roster``, ``lineup``,
+``lineup-health``, ``status``, ``matchup``, and the waiver/transaction flows
+built on the same context.
+
+Payload shape below mirrors the live ``GET /v1/league/<id>/rosters`` response
+(verified 2026-09-03).
+"""
+from __future__ import annotations
+
+from sleeper.types.league import Roster
+
+REAL_PAYLOAD = {
+    "roster_id": 6,
+    "owner_id": "1267509994606051328",
+    "league_id": "1401057434608410624",
+    "starters": ["11564", "12512", "4199", "0", "LAC"],
+    "players": ["11564", "12512", "4199", "2832"],
+    "taxi": ["2832"],
+    "reserve": [],
+    "co_owners": None,
+    "keepers": None,
+    "metadata": {"allow_pn_scoring": "1"},
+    "settings": {
+        "wins": 0,
+        "losses": 0,
+        "ties": 0,
+        "fpts": 0,
+        "fpts_decimal": 0,
+        "fpts_against": 0,
+        "fpts_against_decimal": 0,
+        "waiver_position": 3,
+        "waiver_budget_used": 0,
+        "total_moves": 0,
+    },
+}
+
+
+def test_roster_parses_taxi_and_new_fields():
+    roster = Roster.model_validate(REAL_PAYLOAD)
+    assert roster.taxi == ["2832"]
+    assert roster.reserve == []
+    assert roster.co_owners is None
+    assert roster.keepers is None
+    assert roster.metadata == {"allow_pn_scoring": "1"}
+
+
+def test_roster_new_fields_default_when_absent():
+    payload = dict(REAL_PAYLOAD)
+    for key in ("taxi", "co_owners", "keepers", "metadata"):
+        payload.pop(key, None)
+    roster = Roster.model_validate(payload)
+    assert roster.taxi is None
+    assert roster.co_owners is None
+    assert roster.keepers is None
+    assert roster.metadata is None
+
+
+def test_roster_bench_property_unchanged():
+    roster = Roster.model_validate(REAL_PAYLOAD)
+    assert "2832" in roster.bench
+    assert "11564" not in roster.bench


### PR DESCRIPTION
## Summary
Four agent-CLI breakages found while wrapping sleeper-sdk as MCP tools. Reads crash on a fresh install (missing `inspect_token` export, missing `Roster.taxi`, sync `SleeperClient` context manager). Lineup writes call a GraphQL mutation Sleeper no longer exposes.

## Changes overview
### In ticket / planned scope
- Re-export `inspect_token` from `sleeper.auth` so `auth-check` imports
- Add `taxi` to the `Roster` Pydantic model so roster-touching commands stop throwing
- Stop using `with SleeperClient()` in `waivers` / `inbox` / `outbox` (client is async-only)
- Rewrite `set_starters` to `update_matchup_leg` and pass current week through `lineup-set` / `execute`

### Added while implementing
- Inline GraphQL args to match the live web client (`league_id` / `roster_id` / `leg` / `round` / `starters`)
- Validate snowflake ids and player ids before interpolating into the mutation

## What ships
| Area | What |
| --- | --- |
| `sleeper.auth` | `inspect_token` exported |
| `Roster` | `taxi` field |
| Agent reads | `waivers` / `inbox` / `outbox` no longer crash |
| `lineup-set` | Live week lineup via `update_matchup_leg` |

## Key technical decisions
- In-season lineup writes are matchup-scoped (`leg` + `round` = current NFL week), not a roster-level `update_roster_starters`
- Mutation args are inlined like the Sleeper web bundle; only `starters_games` stays a variable
- Ids are validated before interpolation because the live schema wants literals, not `$league_id: Snowflake!`

## Test plan
- [x] `sleeper auth-check` imports and returns a token envelope
- [x] `sleeper roster` / `status` return `taxi: []` on a real league
- [x] `sleeper waivers` / `inbox` / `outbox` return envelopes (no context-manager crash)
- [x] Live week-1 TE swap via `sleeper_lineup_set` + `execute: true` through MCP (Warren in, Andrews out)

## Docs
- None in this branch

## Related
- Same work already merged to the fork: https://github.com/crimsonsunset/sleeper-sdk/pull/1
- Supersedes https://github.com/cameron-eth/sleeper-sdk/pull/53 (that PR was the feature branch; this one is `crimsonsunset:main`)