### PR TITLE
fix: export inspect_token and replace dead lineup mutation

### DIFF
--- a/python/src/sleeper/auth/__init__.py
+++ b/python/src/sleeper/auth/__init__.py
@@ -13,6 +13,6 @@ Usage:
     client = SleeperAuthClient()
     pending = client.get_trades(league_id, statuses=["pending"])
 """
-from sleeper.auth.client import SleeperAuthClient, SleeperAuthError
+from sleeper.auth.client import SleeperAuthClient, SleeperAuthError, inspect_token
 
-__all__ = ["SleeperAuthClient", "SleeperAuthError"]
+__all__ = ["SleeperAuthClient", "SleeperAuthError", "inspect_token"]

--- a/python/src/sleeper/auth/client.py
+++ b/python/src/sleeper/auth/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import time
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -60,6 +61,25 @@ def _normalize_errors(errs) -> list:
     if isinstance(errs, list):
         return [e if isinstance(e, dict) else {"message": str(e)} for e in errs]
     return [{"message": str(errs)}]
+
+
+def _snowflake(value: str | int) -> str:
+    """Reject anything that is not a numeric Sleeper id before interpolating GraphQL."""
+    s = str(value)
+    if not re.fullmatch(r"[0-9]+", s):
+        raise ValueError(f"invalid sleeper id: {value!r}")
+    return s
+
+
+def _player_ids(ids: list[str]) -> list[str]:
+    """Reject player ids that are not alphanumeric (digits or DEF codes like DEN)."""
+    out: list[str] = []
+    for pid in ids:
+        s = str(pid)
+        if not re.fullmatch(r"[A-Za-z0-9]+", s):
+            raise ValueError(f"invalid player_id: {pid!r}")
+        out.append(s)
+    return out
 
 
 def inspect_token(jwt: str) -> TokenInfo:
@@ -372,27 +392,42 @@ class SleeperAuthClient:
         starters: list[str],
         *,
         leg: int | None = None,
+        round: int | None = None,
     ) -> dict:
-        """Set the starters list for a roster. Order must match league
-        roster_positions slots (excluding BN/IR/TAXI)."""
-        query = """
-        mutation update_roster_starters(
-          $league_id: Snowflake!, $roster_id: Int!, $starters: [String]!, $leg: Int
-        ) {
-          update_roster_starters(
-            league_id: $league_id, roster_id: $roster_id, starters: $starters, leg: $leg
-          ) {
-            roster_id starters players reserve taxi
-          }
-        }
+        """Set the weekly lineup via ``update_matchup_leg``.
+
+        In-season Sleeper no longer exposes ``update_roster_starters``. The web
+        client inlines ``league_id`` / ``roster_id`` / ``leg`` / ``round`` /
+        ``starters`` and only uses a variable for ``starters_games``. ``leg`` and
+        ``round`` are the current NFL week for regular-season matchups.
         """
-        data = self.gql("update_roster_starters", query, {
-            "league_id": league_id,
-            "roster_id": roster_id,
-            "starters": starters,
-            "leg": leg,
-        })
-        return data.get("update_roster_starters") or {}
+        week = int(round if round is not None else (leg if leg is not None else 1))
+        matchup_leg = int(leg if leg is not None else week)
+        safe_league = _snowflake(league_id)
+        safe_roster = int(roster_id)
+        safe_starters = json.dumps(_player_ids(starters))
+        query = f"""
+        mutation update_matchup_leg($starters_games: Map) {{
+          update_matchup_leg(
+            league_id: "{safe_league}",
+            roster_id: {safe_roster},
+            leg: {matchup_leg},
+            round: {week},
+            starters: {safe_starters},
+            starters_games: $starters_games
+          ) {{
+            league_id
+            leg
+            matchup_id
+            roster_id
+            round
+            starters
+            players
+          }}
+        }}
+        """
+        data = self.gql("update_matchup_leg", query, {})
+        return data.get("update_matchup_leg") or {}
 
     def add_drop(
         self,

--- a/python/src/sleeper/cli_agent.py
+++ b/python/src/sleeper/cli_agent.py
@@ -402,12 +402,19 @@ def cmd_lineup_set(args) -> None:
         league_id = ctx["league"]["league_id"]
         roster_id = _resolve_my_roster_id(ctx)
         starters = [s.strip() for s in (args.starters or "").split(",") if s.strip()]
-        payload = {"league_id": league_id, "roster_id": roster_id, "starters": starters}
-        summary = f"Set {len(starters)} starters in {ctx['league']['name']} week {ctx.get('week')}"
+        week = int(ctx.get("week") or 1)
+        payload = {
+            "league_id": league_id,
+            "roster_id": roster_id,
+            "starters": starters,
+            "leg": week,
+            "round": week,
+        }
+        summary = f"Set {len(starters)} starters in {ctx['league']['name']} week {week}"
 
         def _do_write():
             with SleeperAuthClient() as auth:
-                return auth.set_starters(league_id, roster_id, starters)
+                return auth.set_starters(league_id, roster_id, starters, leg=week, round=week)
 
         return _exec_or_preview(args, command="lineup-set", payload=payload,
                                 summary=summary, executor=_do_write)
@@ -546,7 +553,13 @@ def cmd_execute(args) -> None:
                     return auth.accept_trade(p["league_id"], p["transaction_id"], p["leg"])
                 return auth.reject_trade(p["league_id"], p["transaction_id"], p["leg"])
             if cmd == "lineup-set":
-                return auth.set_starters(p["league_id"], p["roster_id"], p["starters"])
+                return auth.set_starters(
+                    p["league_id"],
+                    p["roster_id"],
+                    p["starters"],
+                    leg=p.get("leg"),
+                    round=p.get("round"),
+                )
             if cmd == "waiver-claim":
                 return auth.submit_waiver_claim(
                     p["league_id"], p["roster_id"],


### PR DESCRIPTION
Slimmer follow-up to #54 (closed so it wouldn't compete with #45 / #46 / #51).

Just the two leftover fixes that aren't in those PRs. Both found while wrapping the agent CLI as MCP tools; both break on a live in-season league.

## 1. `auth-check` crashes on import

`cli_agent.py` does `from sleeper.auth import ... inspect_token`, but `sleeper/auth/__init__.py` only exported `SleeperAuthClient` and `SleeperAuthError`.

Fix: re-export `inspect_token`.

## 2. `lineup-set` calls a dead mutation

`set_starters` posted `update_roster_starters`. In-season Sleeper no longer exposes that. The web client uses `update_matchup_leg` with inlined `league_id` / `roster_id` / `leg` / `round` / `starters` (week-scoped).

Captured from a live sleeper.com lineup write, then executed successfully against a real 2026 league (week 1 TE swap).

`lineup-set` / `execute` now pass the current week as `leg` and `round`.